### PR TITLE
Add a Code Style doc and matching .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.java]
+indent_style = space
+indent_size = 4

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+Contributing to Swing Explorer
+==============================
+
+Thank you for your interest in Swing Explorer!
+
+Issue reports of all types are welcome.
+
+### Contributing code
+
+Swing Explorer is a small, focused project. Before doing any work on a big PR, please create an issue report describing it, to see whether it would be accepted or not.
+
+See our [Code Style document](Code-Style.md) for code style guidelines.

--- a/docs/Code-Style.md
+++ b/docs/Code-Style.md
@@ -1,0 +1,59 @@
+SwingExplorer Code Style
+========================
+
+# General
+
+The product name is styled "Swing Explorer" with a space, not "SwingExplorer".
+
+# Source code formatting
+
+Indent with 4 spaces, not tabs.
+
+### Spacing
+
+Use a single blank line at the beginning of class definitions. No blank line at the end of class definitions.
+
+Example:
+
+```java
+class Foo {
+
+    private int x;
+}
+```
+
+Single blank lines between methods.
+
+Group field definitions tightly, with blank lines to separate logical groups.
+
+# Naming conventions
+
+SwingExplorer mostly uses standard Java naming conventions.
+
+### Underscores for args that conflict with fields
+
+If you have a method with an argument that would have the same name as a field (as with property setters), prefix the argument name with an underscore. This is used instead of disambiguating identically-named arguments and fields with a `this.<field>` qualifier.
+
+Example:
+
+```java
+class Person {
+    private name;
+
+    public void setName(String _name) {
+        name = _name;
+    }
+}
+```
+
+### Prefixes for component types
+
+SwingExplorer mostly uses class names with abbreviated prefixes like "`ActDisplayParent`" instead of suffixes like "`DisplayParentAction`".
+
+| Prefix | Meaning |
+| ------ | ------- |
+| Act    | Action  |
+| DLG    | Dialog  |
+| FRM    | Form    |
+| Mdl    | Model   |
+| PNL    | Panel   |


### PR DESCRIPTION
This adds a Code Style document, based on what I've seen in the code. Also adds an .editorconfig to auto-configure editors to use that format.

As for tabs vs spaces, the current codebase has a mix of tabs and spaces, but spaces seem predominant, so I'm assuming that's the standard.

Could you read through the doc and see if I've got it right?