### PR TITLE
Add UJI repository to make org.jdesktop dependency accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@ Swing Explorer
 ======================
 
 A GUI tool for inspecting Java Swing GUIs. It works in a similar way as developer plugins for HTML browsers
-but for Java Swing toolkit. The tool is useful for debugging, testing, inspecting and fine tunning of 
-Swing Applications. 
+but for Java Swing toolkit. The tool is useful for debugging, testing, inspecting and fine tunning of
+Swing Applications.
 
 With Swing Explorer you can:
 - Visually browse through application component hierarchy
 - Monitor AWT/Swing events
 - Debug 2D graphics
-- Easily find places in the source code responsible for creation of certain peaces of UI. 
-- Monitor threading rule violations 
+- Easily find places in the source code responsible for creation of certain peaces of UI.
+- Monitor threading rule violations
 
 Below is shown how basic Swing application is inspected by Swing Explorer.
 More detailed information about Swing Explorer can be found in the User Manual (**TBD**).  
@@ -27,5 +27,6 @@ More detailed information about Swing Explorer can be found in the User Manual (
 
 ##  Building from source
 
-Using maven it is necessary to run `mvn clean package` command from the root folder of cloned project's repository.
-(**TBD** currently not working -->) To test whether the build worked, you can cd in to `swingexplorer-core` and run `dev-tools/launch_sample.sh` to run the sample application.
+Using Maven it is necessary to run `mvn clean package` command from the root folder of cloned project's repository.
+
+To test whether the build worked, you can cd in to `swingexplorer-core` and run `dev-tools/launch_sample.sh` to run the sample application.

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <repositories>
+        <!-- UJI repository needed for org.jdesktop.swing-layout -->
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <id>UJI</id>
+            <name>UJI Repository</name>
+            <url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+            <layout>default</layout>
+        </repository>
+    </repositories>
+
     <modules>
         <module>swingexplorer-core</module>
         <module>swingexplorer-agent</module>


### PR DESCRIPTION
This fixes the following error:

```
ERROR] Failed to execute goal on project swingexplorer-core: Could not resolve dependencies for project org.swingexplorer:swingexplorer-core:jar:1.7.0-SNAPSHOT: Could not find artifact org.jdesktop:swing-layout:jar:1.0.3 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```

Unlike most Maven-managed open source projects, org.jdesktop is not in Maven Central, but in its own separate repository, so it's necessary to add that repository in to our POM setup. This was lost in the POM reorganization.

With this change, the build from the root POM is working.