### PR TITLE
Switch org.jdesktop swing-layout to org.swinglabs swing-layout

### DIFF
--- a/swingexplorer-core/pom.xml
+++ b/swingexplorer-core/pom.xml
@@ -21,7 +21,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jdesktop</groupId>
+            <!-- org.jdesktop swing-layout -->
+            <groupId>org.swinglabs</groupId>
             <artifactId>swing-layout</artifactId>
             <version>1.0.3</version>
         </dependency>


### PR DESCRIPTION
This is so it can be downloaded from the default Maven Central repos.

Closes #10 because this provides an alternate way of getting the same library.