### PR TITLE
Update repo links in main pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/swingexplorer/swingexplorer-core.git</connection>
-        <developerConnection>scm:git:ssh://github.com:swingexplorer/swingexplorer-core.git</developerConnection>
-        <url>https://github.com/swingexplorer/swingexplorer-core</url>
+        <connection>scm:git:git://github.com/swingexplorer/swingexplorer.git</connection>
+        <developerConnection>scm:git:ssh://github.com:swingexplorer/swingexplorer-.git</developerConnection>
+        <url>https://github.com/swingexplorer/swingexplorer</url>
     </scm>
 
     <properties>


### PR DESCRIPTION
This updates the "scm" section of the main pom.xml to reflect our merging of the swingexplorer-core and swingexplorer-agent repos into a single "swingexplorer" repo.