### PR TITLE
Switch .editorconfig to Windows-style CRLF lines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
 root = true
 
-# Unix-style newlines with a newline ending every file
+# Windows-style newlines with a newline ending every file
 [*]
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 
 # 4 space indentation

--- a/swingexplorer-core/pom.xml
+++ b/swingexplorer-core/pom.xml
@@ -21,7 +21,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jdesktop</groupId>
+            <!-- org.jdesktop swing-layout -->
+            <groupId>org.swinglabs</groupId>
             <artifactId>swing-layout</artifactId>
             <version>1.0.3</version>
         </dependency>


### PR DESCRIPTION
This PR switches .editorconfig to use Windows-style CRLF lines, since it looks like that's what the existing source code is using.

This will prevent my source code checkins from spuriously changing the line feeds in files I modify.