### PR TITLE
Fix some compiler warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,9 @@ root = true
 end_of_line = crlf
 insert_final_newline = true
 
+[*.sh]
+end_of_line = lf
+
 # 4 space indentation
 [*.java]
 indent_style = space

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java
@@ -36,7 +36,7 @@ import javax.swing.UIManager;
  *
  * @author  Maxim Zakharenkov
  */
-public class ColorComboBox extends JComboBox {
+public class ColorComboBox extends JComboBox<Color> {
 
 	
 	public ColorComboBox() {
@@ -63,8 +63,12 @@ public class ColorComboBox extends JComboBox {
 	public Color getSelectedColor() {
 		return (Color)getSelectedItem();
 	}
-	
-	
+
+	@SuppressWarnings("unchecked")
+	public void setRenderer(ListCellRenderer aRenderer) {
+        super.setRenderer(aRenderer);
+    }
+
 	
 	static class ColorCellRenderer extends DefaultListCellRenderer {
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
@@ -310,7 +310,7 @@ public class MdlSwingExplorer {
 			
             // basic popup and tooltip  must be shown before painting
             if(displayedComponent instanceof BasicComboPopup || displayedComponent instanceof JToolTip) {
-                ((JComponent)displayedComponent).show();
+                ((JComponent)displayedComponent).setVisible(true);
             }
             if(displayedComponent instanceof JToolTip) {
                 displayedComponent.setSize(displayedComponent.getPreferredSize());
@@ -336,7 +336,7 @@ public class MdlSwingExplorer {
             
 			//  basic popup and tooltip must be shown before painting
             if(displayedComponent instanceof BasicComboPopup || displayedComponent instanceof JToolTip) {
-                ((JComponent)displayedComponent).hide();
+                ((JComponent)displayedComponent).setVisible(false);
             }
 		}
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java
@@ -58,7 +58,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     private void initComponents() {
 
         scpOperations = new javax.swing.JScrollPane();
-        lstOperations = new javax.swing.JList();
+        lstOperations = new javax.swing.JList<>();
         slider = new javax.swing.JSlider();
         spinner = new javax.swing.JSpinner();
         btnPlayPause = new javax.swing.JButton();
@@ -69,11 +69,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
         btnDumpStackTrace = new javax.swing.JButton();
         btnSrc = new javax.swing.JButton();
 
-        lstOperations.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
+        lstOperations.setModel(new OperationListModel());
         lstOperations.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
         lstOperations.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
             public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
@@ -212,7 +208,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     private javax.swing.JButton btnSrc;
     private javax.swing.JButton btnToEnd;
     private javax.swing.JButton btnToStart;
-    private javax.swing.JList lstOperations;
+    private javax.swing.JList<Operation> lstOperations;
     private javax.swing.JScrollPane scpOperations;
     private javax.swing.JSlider slider;
     private javax.swing.JSpinner spinner;
@@ -350,7 +346,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
 		}        
     }
     
-    class OperationListModel extends AbstractListModel {
+    class OperationListModel extends AbstractListModel<Operation> {
 
     	Operation[] operations = new Operation[0];
 
@@ -375,7 +371,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
 			return operations.length;
 		}
 
-		public Object getElementAt(int index) {
+		public Operation getElementAt(int index) {
 			return operations[index];
 		}    	
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
@@ -255,7 +255,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
     ModelListener listener = new ModelListener();
     PlayerListener playerListener = new PlayerListenerImpl();
     
-    JComboBox  cmbScale = new JComboBox();
+    JComboBox<String> cmbScale = new JComboBox<>();
     
     ActRefresh actRefresh;
     ActDisplayComponent actDisplayComponent;
@@ -304,7 +304,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
         cmbScale.setEditable(true);
         //cmbScale.setPreferredSize(new Dimension(20,16));
         cmbScale.setMaximumSize(new Dimension(60, 20));
-        cmbScale.setModel(new DefaultComboBoxModel(new String[]{"25%", "50%", "75%", "100%", "125%", "150%", "175%", "200%"}));
+        cmbScale.setModel(new DefaultComboBoxModel<String>(new String[]{"25%", "50%", "75%", "100%", "125%", "150%", "175%", "200%"}));
         tlbMain.add(cmbScale);
         cmbScale.setSelectedItem("" + (int)(application.model.getDisplayScale()*100) + "%");
         

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
@@ -35,7 +35,8 @@ public abstract class AbstractOnResizePersonalizer<T extends Component> implemen
 
 	protected Options options;
 	protected T component;
-	
+
+	@SuppressWarnings("unchecked")
 	public void install(Options _options, Component _component) {
 		component = (T)_component;
 		options = _options;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
@@ -61,7 +61,8 @@ public class CustomComboBoxUI extends MetalComboBoxUI {
             paintCurrentValue(g,r,hasFocus);
         }
     }
-    
+
+    @SuppressWarnings("unchecked")
     public void paintCurrentValue(Graphics g,Rectangle bounds,boolean hasFocus) {
         ListCellRenderer renderer = comboBox.getRenderer();
         Component c;

--- a/swingexplorer-core/src/main/java/sample/FrmPerson.java
+++ b/swingexplorer-core/src/main/java/sample/FrmPerson.java
@@ -54,7 +54,7 @@ public class FrmPerson extends javax.swing.JFrame {
         rbnMale = new javax.swing.JRadioButton();
         rbnFemale = new javax.swing.JRadioButton();
         lblCountry = new javax.swing.JLabel();
-        cmbCountry = new javax.swing.JComboBox();
+        cmbCountry = new javax.swing.JComboBox<String>();
         lblDescription = new javax.swing.JLabel();
         btnModalDialog = new javax.swing.JButton();
         btnOwnerlessModalDialog = new javax.swing.JButton();
@@ -122,7 +122,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         lblCountry.setText("Country:");
 
-        cmbCountry.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "England", "Belgium", "France", "Spain", "Italy", "Germany" }));
+        cmbCountry.setModel(new javax.swing.DefaultComboBoxModel<String>(new String[] { "England", "Belgium", "France", "Spain", "Italy", "Germany" }));
 
         lblDescription.setFont(new java.awt.Font("Tahoma", 1, 12));
         lblDescription.setText("This is sample Swing application to demonstrate Swing Explorer");
@@ -370,7 +370,7 @@ public class FrmPerson extends javax.swing.JFrame {
     private javax.swing.JButton btnThreadViolation;
     private javax.swing.JButton btnThreadViolation2;
     private javax.swing.JButton btnThreadViolation3;
-    private javax.swing.JComboBox cmbCountry;
+    private javax.swing.JComboBox<String> cmbCountry;
     private javax.swing.ButtonGroup grpGender;
     private javax.swing.JLabel lblCountry;
     private javax.swing.JLabel lblDescription;


### PR DESCRIPTION
This fixes some compiler warnings that have crept back in to the build.

Fixes #15.

###  Details

This mostly fixes the warnings by adding type parameters. The ListCellRenderer
stuff can't be fixed like that, though, because DefaultListCellRenderer
is already parameterized to type Object. So I suppressed those warnings
instead.

Also, deprecated `show()`/`hide()` calls are replaced with `setVisible(...)` calls.

I also switched `PNLPlayerControllers.java` to always use an `OperationListModel`, even for the initial dummy data. 

Before:

```
[INFO] Compiling 117 source files to /Users/janke/local/repos/swingexplorer/swingexplorer-core/target/classes
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[34,17] sun.swing.DefaultLookup is internal proprietary API and may be removed in a future release
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java:[72,31] unchecked call to setModel(javax.swing.ListModel<E>) as a member of the raw type javax.swing.JList
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java:[242,31] unchecked call to setModel(javax.swing.ListModel<E>) as a member of the raw type javax.swing.JList
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java:[313,49] show() in java.awt.Component has been deprecated
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java:[339,49] hide() in javax.swing.JComponent has been deprecated
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java:[307,27] unchecked call to DefaultComboBoxModel(E[]) as a member of the raw type javax.swing.DefaultComboBoxModel
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java:[307,26] unchecked call to setModel(javax.swing.ComboBoxModel<E>) as a member of the raw type javax.swing.JComboBox
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java:[56,25] unchecked call to setModel(javax.swing.ComboBoxModel<E>) as a member of the raw type javax.swing.JComboBox
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java:[59,28] unchecked call to setRenderer(javax.swing.ListCellRenderer<? super E>) as a member of the raw type javax.swing.JComboBox
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/sample/FrmPerson.java:[125,29] unchecked call to DefaultComboBoxModel(E[]) as a member of the raw type javax.swing.DefaultComboBoxModel
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/sample/FrmPerson.java:[125,28] unchecked call to setModel(javax.swing.ComboBoxModel<E>) as a member of the raw type javax.swing.JComboBox
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java:[40,32] unchecked cast
  required: T
  found:    java.awt.Component
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[72,54] unchecked call to getListCellRendererComponent(javax.swing.JList<? extends E>,E,int,boolean,boolean) as a member of the raw type javax.swing.ListCellRenderer
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[79,54] unchecked call to getListCellRendererComponent(javax.swing.JList<? extends E>,E,int,boolean,boolean) as a member of the raw type javax.swing.ListCellRenderer
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[97,33] sun.swing.DefaultLookup is internal proprietary API and may be removed in a future release
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[99,33] sun.swing.DefaultLookup is internal proprietary API and may be removed in a future release
```

After:

All that remains are warnings about the internal proprietary sun.swing.DefaultLookup. These warnings cannot (officially) be suppressed.

```
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[34,17] sun.swing.DefaultLookup is internal proprietary API and may be removed in a future release
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[98,33] sun.swing.DefaultLookup is internal proprietary API and may be removed in a future release
[WARNING] /Users/janke/local/repos/swingexplorer/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java:[100,33] sun.swing.DefaultLookup is internal proprietary API and may be removed in a future release
```