### PR TITLE
Refactor: Modernize code for Java 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,9 @@ root = true
 end_of_line = crlf
 insert_final_newline = true
 
+[*.sh]
+end_of_line = lf
+
 # 4 space indentation
 [*.java]
 indent_style = space

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActRefresh.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActRefresh.java
@@ -149,10 +149,7 @@ public class ActRefresh extends RichAction {
                 return false;
             }
         }
-        if(enum2.hasMoreElements()) {
-            return false;
-        }
-        return true;
+        return !enum2.hasMoreElements();
     }
     
     
@@ -168,7 +165,7 @@ public class ActRefresh extends RichAction {
 		boolean forJDK15; 
 		try {
 			//	Try JRE 1.6 first through reflection
-			Method meth = Window.class.getMethod("getWindows", new Class[0]);
+			Method meth = Window.class.getMethod("getWindows");
 			allWindows = (Window[])meth.invoke(Window.class, new Object[0]);
 			forJDK15 = false;
 		} catch (Exception e) {
@@ -204,7 +201,7 @@ public class ActRefresh extends RichAction {
 			list.add(curWindow);
 		}
 		
-		addChildren(root, list.toArray(new Window[list.size()]), forJDK15);		
+		addChildren(root, list.toArray(new Window[0]), forJDK15);
 	}
 	
 	String getWindowTitle(Window wnd) {
@@ -218,19 +215,19 @@ public class ActRefresh extends RichAction {
 	}
 	
 	void addChildren(DefaultMutableTreeNode root, Window[] windows, boolean forJRE15) {
-		for (int i = 0; i < windows.length; i++) {
-			TreeNodeObject object = new TreeNodeObject(windows[i], getWindowTitle(windows[i]));
-			DefaultMutableTreeNode child = new DefaultMutableTreeNode(object);
-			root.add(child);
-			addChildren(child, windows[i]);
-			
-			if(forJRE15) {
-				// for JRE 1.5 we need to get also owned dialogs since they are not
-				// available from Frame.getFrames()
-				Window[] ownedWnds = windows[i].getOwnedWindows();
-				addChildren(root, ownedWnds, forJRE15);
-			}
-		}
+        for (Window window : windows) {
+            TreeNodeObject object = new TreeNodeObject(window, getWindowTitle(window));
+            DefaultMutableTreeNode child = new DefaultMutableTreeNode(object);
+            root.add(child);
+            addChildren(child, window);
+
+            if (forJRE15) {
+                // for JRE 1.5 we need to get also owned dialogs since they are not
+                // available from Frame.getFrames()
+                Window[] ownedWnds = window.getOwnedWindows();
+                addChildren(root, ownedWnds, forJRE15);
+            }
+        }
 		
 	}
 	
@@ -245,7 +242,7 @@ public class ActRefresh extends RichAction {
 			} else {
 				// Next try to obtain description as "getText" if available
 	            try {
-	                Method meth = comp.getClass().getMethod("getText", new Class[0]);
+	                Method meth = comp.getClass().getMethod("getText");
 	                String result = (String)meth.invoke(comp, new Object[0]);
 	                name = comp.getClass().getSimpleName() + "(" + result + ")";
 	            } catch (Exception e) {
@@ -324,7 +321,7 @@ public class ActRefresh extends RichAction {
     
 	static Frame getSharedOwnerFrame() {
 		try {
-			Method meth = SwingUtilities.class.getDeclaredMethod("getSharedOwnerFrame", new Class[]{});
+			Method meth = SwingUtilities.class.getDeclaredMethod("getSharedOwnerFrame");
 			meth.setAccessible(true);
 			return (Frame)meth.invoke(null, new Object[]{});
 		} catch (Exception e) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -44,7 +44,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {
 
-			Component component = pnlComponentTree.getComponent(curPath);
+			Component component = PNLComponentTree.getComponent(curPath);
 
 			if (e.isAddedPath(curPath)) {
 				model.addSelection(component);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedIcon.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedIcon.java
@@ -70,7 +70,7 @@ public class AnimatedIcon implements Icon {
         
         // calculate maximal icon size and set icons to list
         maxIconSize = new Dimension(0, 0);
-        for(int i = 0; i < _icons.length; i++) {
+        for (int i = 0; i < _icons.length; i++) {
             Icon curIcon = _icons[i] == null ? EMPTY_ICON : _icons[i];
             maxIconSize.height = Math.max(curIcon.getIconHeight(), maxIconSize.height);
             maxIconSize.width = Math.max(curIcon.getIconWidth(), maxIconSize.width);
@@ -84,7 +84,7 @@ public class AnimatedIcon implements Icon {
      * @return
      */
     public Icon[] getIcons() {
-        return icons.toArray(new Icon[icons.size()]);
+        return icons.toArray(new Icon[0]);
     }
     
     public AnimatedIcon(JComponent _ownerComponent) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedLabel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedLabel.java
@@ -63,11 +63,10 @@ public class AnimatedLabel extends JLabel {
         
         // calculate maximal icon size and set icons to list
         maxIconSize = new Dimension(0, 0);
-        for(int i = 0; i < _icons.length; i++) {
-            Icon curIcon = _icons[i] == null ? EMPTY_ICON : _icons[i];
+        for (Icon _icon : _icons) {
+            Icon curIcon = _icon == null ? EMPTY_ICON : _icon;
             maxIconSize.height = Math.max(curIcon.getIconHeight(), maxIconSize.height);
             maxIconSize.width = Math.max(curIcon.getIconWidth(), maxIconSize.width);
-            
             icons.add(curIcon);
         }
     }
@@ -77,7 +76,7 @@ public class AnimatedLabel extends JLabel {
      * @return
      */
     public Icon[] getIcons() {
-        return icons.toArray(new Icon[icons.size()]);
+        return icons.toArray(new Icon[0]);
     }
     
     public AnimatedLabel() {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java
@@ -36,7 +36,7 @@ import javax.swing.UIManager;
  *
  * @author  Maxim Zakharenkov
  */
-public class ColorComboBox extends JComboBox {
+public class ColorComboBox extends JComboBox<Color> {
 
 	
 	public ColorComboBox() {
@@ -63,8 +63,12 @@ public class ColorComboBox extends JComboBox {
 	public Color getSelectedColor() {
 		return (Color)getSelectedItem();
 	}
-	
-	
+
+	@SuppressWarnings("unchecked")
+	public void setRenderer(ListCellRenderer aRenderer) {
+        super.setRenderer(aRenderer);
+    }
+
 	
 	static class ColorCellRenderer extends DefaultListCellRenderer {
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/FrmSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/FrmSwingExplorer.java
@@ -77,7 +77,7 @@ public class FrmSwingExplorer extends JFrame {
 			Field field = exclusionType.getField("APPLICATION_EXCLUDE");
 			Object value = field.get(exclusionType);
 			
-			Method meth = JFrame.class.getMethod("setModalExclusionType", new Class[]{exclusionType});
+			Method meth = JFrame.class.getMethod("setModalExclusionType", exclusionType);
 			meth.invoke(this, value);
 		} catch (Exception e) {
 			Log.general.warn("Application exclusive modality is not available on this Java platform. It is recommended to use java 1.6 or later.");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/GuiUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/GuiUtils.java
@@ -191,7 +191,7 @@ final public class GuiUtils {
             result = SwingUtilities.getWindowAncestor(component);
         } else {
             throw new NullPointerException(
-                MessageFormat.format("Cannot find parent window for component \"{0}\"", new Object[] { component }));
+                MessageFormat.format("Cannot find parent window for component \"{0}\"", component));
         }
         return result;
     }
@@ -293,7 +293,7 @@ final public class GuiUtils {
         if (text == null) {
             return null;
         }
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         int idx = 0;
         while (idx < text.length()) {
             char c = text.charAt(idx++);
@@ -352,10 +352,10 @@ final public class GuiUtils {
      */
     public static JPopupMenu createPopupMenu(Action[] actions) {
         JPopupMenu result = new JPopupMenu();
-        for (int i = 0; i < actions.length; i++) {
-            if (actions[i] != null) {
+        for (Action action : actions) {
+            if (action != null) {
 
-                JMenuItem item = new JMenuItem(actions[i]) {
+                JMenuItem item = new JMenuItem(action) {
                     public void setText(String text) {
                         super.setText(GuiUtils.getTextWithoutMnemonic(text));
                     }
@@ -525,16 +525,15 @@ final public class GuiUtils {
         Constructor<?> ctor = null;
         try {
             if (owner instanceof Dialog) {
-                ctor = dialogClass.getConstructor(new Class[] { Dialog.class });
+                ctor = dialogClass.getConstructor(Dialog.class);
                 result = (Dialog) ctor.newInstance(new Object[] { owner });
 
             } else if (owner instanceof Frame) {
-                ctor = dialogClass.getConstructor(new Class[] { Frame.class });
+                ctor = dialogClass.getConstructor(Frame.class);
                 result = (Dialog) ctor.newInstance(new Object[] { owner });
 
             } else {
-                ctor = dialogClass.getConstructor(new Class[] {
-                });
+                ctor = dialogClass.getConstructor();
                 result = (Dialog) ctor.newInstance(new Object[] {
                 });
             }
@@ -552,8 +551,7 @@ final public class GuiUtils {
      */
     public static Enumeration<TreePath> getExpatnedTreePaths(JTree tree) {
         TreePath pathToRoot = new TreePath(tree.getModel().getRoot());
-        Enumeration<TreePath> expandPaths = tree.getExpandedDescendants(pathToRoot);
-        return expandPaths;
+        return tree.getExpandedDescendants(pathToRoot);
     }
     
     /**

--- a/swingexplorer-core/src/main/java/org/swingexplorer/Launcher.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/Launcher.java
@@ -179,16 +179,14 @@ public class Launcher implements Runnable {
             return;
         }
     	newArgs = new String[args.length - 1];
-		for (int i = 0; i < newArgs.length; i++) {
-			newArgs[i] = args[i + 1];
-		}
+        System.arraycopy(args, 1, newArgs, 0, newArgs.length);
 
         String userProgramClassName = args[0];
         customizeProgramAppearance(userProgramClassName);
 
         try {
             mainClass = Class.forName(userProgramClassName);
-			mainMethod = mainClass.getMethod("main", new Class[]{String[].class});
+            mainMethod = mainClass.getMethod("main", String[].class);
         } catch(ClassNotFoundException ex) {
             String msg = MessageFormat.format("ERROR: can not find class {0} specified as argument. Please check classpath and class name.",
                 userProgramClassName);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
@@ -310,7 +310,7 @@ public class MdlSwingExplorer {
 			
             // basic popup and tooltip  must be shown before painting
             if(displayedComponent instanceof BasicComboPopup || displayedComponent instanceof JToolTip) {
-                ((JComponent)displayedComponent).show();
+                ((JComponent)displayedComponent).setVisible(true);
             }
             if(displayedComponent instanceof JToolTip) {
                 displayedComponent.setSize(displayedComponent.getPreferredSize());
@@ -336,7 +336,7 @@ public class MdlSwingExplorer {
             
 			//  basic popup and tooltip must be shown before painting
             if(displayedComponent instanceof BasicComboPopup || displayedComponent instanceof JToolTip) {
-                ((JComponent)displayedComponent).hide();
+                ((JComponent)displayedComponent).setVisible(false);
             }
 		}
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
@@ -97,7 +97,7 @@ public class MdlSwingExplorer {
 	 * @param newVal
 	 */
 	protected void fireCheckedPropertyChange(String prop, Object oldVal, Object newVal) {
-		if(oldVal != null && newVal != null && oldVal.equals(newVal)) {
+		if(oldVal != null && oldVal.equals(newVal)) {
 			return;
 		}
 		if(oldVal == newVal) {
@@ -106,6 +106,7 @@ public class MdlSwingExplorer {
 		
 		firePropertyChange(prop, oldVal, newVal);
 	}
+
 	protected void firePropertyChange(String prop, Object oldVal, Object newVal) {
 		log("Property %1$s changed\n", prop);
 		
@@ -177,7 +178,7 @@ public class MdlSwingExplorer {
 	}
 
 	public Component[] getSelectedComponents() {
-		return selectedComponents.toArray(new Component[selectedComponents.size()]);
+		return selectedComponents.toArray(new Component[0]);
 	}
 
 	public void addSelection(Component selection) {
@@ -248,7 +249,7 @@ public class MdlSwingExplorer {
 		this.displayedComponent = displayedComponent;
 		fireCheckedPropertyChange("displayedComponent", oldVal, displayedComponent);
 		
-		if(oldVal != null && displayedComponent != null && oldVal.equals(displayedComponent)) {
+		if(oldVal != null && oldVal.equals(displayedComponent)) {
 			return;
 		}
 		if(oldVal == displayedComponent) {
@@ -352,7 +353,7 @@ public class MdlSwingExplorer {
 			buf.insert(0, "/");
 			
 			if(showIndex) {
-				if(index != -1 && showIndex) {
+				if(index != -1) {
 					buf.insert(0, ']');
 					buf.insert(0, index);
 					buf.insert(0, '[');
@@ -378,7 +379,7 @@ public class MdlSwingExplorer {
 	 */
 	private int getComponentIndex(Component comp) {
 		Container parent = (Container)comp.getParent();
-		if(parent == null || comp == null) {
+		if(parent == null) {
 			return -1;
 		}
 		for(int i = 0; i< parent.getComponentCount(); i++) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlAbout.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlAbout.java
@@ -36,16 +36,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Calendar;
 
-import javax.swing.ButtonModel;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JTextPane;
-import javax.swing.SwingConstants;
-import javax.swing.UIManager;
+import javax.swing.*;
 
 
 /**
@@ -166,7 +157,7 @@ public class PnlAbout extends javax.swing.JPanel {
 
 	public static void main(String[] args) {
 		JFrame frm = new JFrame();
-		frm.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		frm.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		frm.setBounds(100,  100, 400, 300);
 		frm.setVisible(true);
 		openModal(frm);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlGuiDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlGuiDisplay.java
@@ -172,14 +172,10 @@ public class PnlGuiDisplay extends JComponent {
 
 		g.setColor(settings.getMeasureLineColor());
 
-		if (p1 != null) {
-			paintMeasurePoint(g, p1, size);
-		}
-		if (p2 != null) {
-			paintMeasurePoint(g, p2, size);
-		}
+        paintMeasurePoint(g, p1, size);
+        paintMeasurePoint(g, p2, size);
 
-		if (p1 != null && p2 != null && !p1.equals(p2)) {
+        if (!p1.equals(p2)) {
 			g.setStroke(settings.getMeasureLineStroke());
 			g.drawLine(p1.x, p1.y, p2.x, p2.y);
 			

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlOptions.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlOptions.java
@@ -198,7 +198,7 @@ public class PnlOptions extends javax.swing.JPanel {
 			if(disabled) {
 				return;
 			}
-			if(evt.getSource() == chbDisplayPreferredSize || evt.getStateChange() == evt.SELECTED) {
+			if(evt.getSource() == chbDisplayPreferredSize || evt.getStateChange() == ItemEvent.SELECTED) {
 				updateOptions();
 			}
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java
@@ -58,7 +58,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     private void initComponents() {
 
         scpOperations = new javax.swing.JScrollPane();
-        lstOperations = new javax.swing.JList();
+        lstOperations = new javax.swing.JList<>();
         slider = new javax.swing.JSlider();
         spinner = new javax.swing.JSpinner();
         btnPlayPause = new javax.swing.JButton();
@@ -69,11 +69,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
         btnDumpStackTrace = new javax.swing.JButton();
         btnSrc = new javax.swing.JButton();
 
-        lstOperations.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
+        lstOperations.setModel(new OperationListModel());
         lstOperations.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
         lstOperations.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
             public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
@@ -212,7 +208,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     private javax.swing.JButton btnSrc;
     private javax.swing.JButton btnToEnd;
     private javax.swing.JButton btnToStart;
-    private javax.swing.JList lstOperations;
+    private javax.swing.JList<Operation> lstOperations;
     private javax.swing.JScrollPane scpOperations;
     private javax.swing.JSlider slider;
     private javax.swing.JSpinner spinner;
@@ -350,7 +346,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
 		}        
     }
     
-    class OperationListModel extends AbstractListModel {
+    class OperationListModel extends AbstractListModel<Operation> {
 
     	Operation[] operations = new Operation[0];
 
@@ -375,7 +371,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
 			return operations.length;
 		}
 
-		public Object getElementAt(int index) {
+		public Operation getElementAt(int index) {
 			return operations[index];
 		}    	
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
@@ -255,7 +255,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
     ModelListener listener = new ModelListener();
     PlayerListener playerListener = new PlayerListenerImpl();
     
-    JComboBox  cmbScale = new JComboBox();
+    JComboBox<String> cmbScale = new JComboBox<>();
     
     ActRefresh actRefresh;
     ActDisplayComponent actDisplayComponent;
@@ -304,7 +304,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
         cmbScale.setEditable(true);
         //cmbScale.setPreferredSize(new Dimension(20,16));
         cmbScale.setMaximumSize(new Dimension(60, 20));
-        cmbScale.setModel(new DefaultComboBoxModel(new String[]{"25%", "50%", "75%", "100%", "125%", "150%", "175%", "200%"}));
+        cmbScale.setModel(new DefaultComboBoxModel<String>(new String[]{"25%", "50%", "75%", "100%", "125%", "150%", "175%", "200%"}));
         tlbMain.add(cmbScale);
         cmbScale.setSelectedItem("" + (int)(application.model.getDisplayScale()*100) + "%");
         

--- a/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleAction.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleAction.java
@@ -28,7 +28,7 @@ public abstract class RichToggleAction extends RichAction {
 
 	
 	public void setSelected(boolean isSelected) {
-		putValue("selected", new Boolean(isSelected));
+		putValue("selected", isSelected);
 	}
 	
 	public boolean isSelected() {
@@ -36,7 +36,7 @@ public abstract class RichToggleAction extends RichAction {
 		if(selected == null) {
 			return false;
 		}
-		return selected.booleanValue();
+		return selected;
 	}
 }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleButton.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleButton.java
@@ -42,8 +42,8 @@ public class RichToggleButton extends JToggleButton {
 		this();
 		setAction(a);
 	}
-	
-	
+
+
 	@Override
 	public void setAction(Action a) {
 		if(a instanceof RichToggleAction) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/RichToolbar.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/RichToolbar.java
@@ -38,7 +38,7 @@ public class RichToolbar extends JToolBar {
 	public AbstractButton addActionEx(Action a) {
 		String text = a != null ? (String) a.getValue(Action.NAME) : null;
 		Icon icon = a != null ? (Icon) a.getValue(Action.SMALL_ICON) : null;
-		boolean enabled = a != null ? a.isEnabled() : true;
+		boolean enabled = a == null || a.isEnabled();
 		String tooltip = a != null ? (String) a
 				.getValue(Action.SHORT_DESCRIPTION) : null;
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/BeanSaver.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/BeanSaver.java
@@ -109,7 +109,7 @@ public class BeanSaver {
 				
 				Method setter = findSetterSafe(bean.getClass(), property);
 
-				setter.invoke(bean, new Object[]{defaultValue});
+				setter.invoke(bean, defaultValue);
 			}
 		}catch(Exception ex) {
 			throw new RuntimeException(ex);
@@ -140,7 +140,7 @@ public class BeanSaver {
 	public Object getValue(Object bean, String property) {
 		Method method = findGetterSafe(bean.getClass(), property);
 		try {
-			return method.invoke(bean, new Object[0]);
+			return method.invoke(bean);
 		} catch (Exception e) {
 			throw new RuntimeException("Error invoking getter for \"" + bean.getClass() + " bean's  property \"" + property + "\"");
 		}
@@ -155,7 +155,7 @@ public class BeanSaver {
 	public void setValue(Object bean, String property, Object value) {
 		Method method = findSetterSafe(bean.getClass(), property);
 		try {
-			method.invoke(bean, new Object[] {value});
+			method.invoke(bean, value);
 		} catch (Exception e) {
 			throw new RuntimeException("Error invoking setter for \"" + bean.getClass() + " bean's  property \"" + property + "\"");
 		}
@@ -258,7 +258,7 @@ public class BeanSaver {
 		String setterName = "set" + first.toUpperCase() + rest;
 		
 		try {
-			Method setter = beanClass.getMethod(setterName, new Class<?>[] {type});
+			Method setter = beanClass.getMethod(setterName, type);
 			return setter;
 		} catch (Exception e) {
 			return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/ColorConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/ColorConverter.java
@@ -21,6 +21,7 @@ package org.swingexplorer.beans;
 
 import java.awt.Color;
 import java.text.ParseException;
+import java.util.Arrays;
 
 /**
  *
@@ -36,7 +37,7 @@ public class ColorConverter implements Converter<Color> {
 		String[] strRgb = strValue.split(",");
 		
 		if(strRgb.length < 3 || strRgb.length > 4) {
-			throw new ParseException("Wrong color string \"" + strRgb + "\" Number of color components must be either 3 of 4 (r,g,b,alpha)",0);
+			throw new ParseException("Wrong color string \"" + Arrays.toString(strRgb) + "\" Number of color components must be either 3 of 4 (r,g,b,alpha)",0);
 		}
 		try {
 			

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntArrayConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntArrayConverter.java
@@ -56,7 +56,7 @@ public class IntArrayConverter implements Converter<int[]>{
 		
 		StringBuilder buf = new StringBuilder();
 		for(int v : value) {
-			buf.append(v + ",");
+			buf.append(v).append(",");
 		}
 		
 		// remove last ,

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/EDTDebugQueue.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/EDTDebugQueue.java
@@ -170,7 +170,7 @@ public class EDTDebugQueue extends EventQueue {
                     return false;
                 }
                 for (int i = 0; i < a.length; ++i) {
-                    if (a[i].equals(b[i]) == false) {
+                    if (!a[i].equals(b[i])) {
                         return false;
                     }
                 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Operation.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Operation.java
@@ -90,8 +90,8 @@ public class Operation {
 			return "END.";
 		}
 		
-		StringBuffer sb = new StringBuffer();
-		sb.append(method.getName() + "(");
+		StringBuilder sb = new StringBuilder();
+		sb.append(method.getName()).append("(");
 		Class<?>[] params = method.getParameterTypes();
 		for (int j = 0; j < params.length; j++) {
 			sb.append(getTypeName(params[j]));

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Player.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Player.java
@@ -164,7 +164,7 @@ public class Player {
 		currentGraphics.dispose();
 		
 		// set operations to player
-		setOperations(newOperations.toArray(new Operation[newOperations.size()]), component.getSize());
+		setOperations(newOperations.toArray(new Operation[0]), component.getSize());
 		
 		// current operation is END now
 		setCurrentOperationIndex(this.operations.length - 1);
@@ -266,10 +266,8 @@ public class Player {
 		
 		// set current position and fire event about position change
 		setCurrentOperationIndex(seekPosition);
-		
-		if (op != null) {
-			fireImageRenderedEvent(workerImage, op);
-		}
+
+        fireImageRenderedEvent(workerImage, op);
     }
     
     private void doOperation(Operation op) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/XGraphics.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/XGraphics.java
@@ -598,8 +598,8 @@ public class XGraphics extends Graphics2D {
 		}
 		Object cloned = null;
 		try {
-			Method cloneMeth = toClone.getClass().getMethod("clone", new Class[0]);
-			cloned = cloneMeth.invoke(toClone, new Object[0]);
+			Method cloneMeth = toClone.getClass().getMethod("clone");
+			cloned = cloneMeth.invoke(toClone);
 		} catch(Exception ex) {
 			// can not clone object, 
 			// this potentially may rise problems when playback

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
@@ -35,7 +35,8 @@ public abstract class AbstractOnResizePersonalizer<T extends Component> implemen
 
 	protected Options options;
 	protected T component;
-	
+
+	@SuppressWarnings("unchecked")
 	public void install(Options _options, Component _component) {
 		component = (T)_component;
 		options = _options;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
@@ -61,7 +61,8 @@ public class CustomComboBoxUI extends MetalComboBoxUI {
             paintCurrentValue(g,r,hasFocus);
         }
     }
-    
+
+    @SuppressWarnings("unchecked")
     public void paintCurrentValue(Graphics g,Rectangle bounds,boolean hasFocus) {
         ListCellRenderer renderer = comboBox.getRenderer();
         Component c;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/properties/MdlProperties.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/properties/MdlProperties.java
@@ -48,9 +48,8 @@ public class MdlProperties extends AbstractTableModel {
 	String[] colNames = new String[] {"name", "value"};
 	
     // properties shown first of all at the beginning
-    HashSet<String> firstKeys = new HashSet<String>(Arrays.asList(new String[] {
-                    "size", "opaque", "class", "constraints", "location", "locationOnScreen", "visible", "layout", "border", "borderInsets"            
-                }));
+    HashSet<String> firstKeys = new HashSet<String>(Arrays.asList("size", "opaque", "class", "constraints", "location",
+        "locationOnScreen", "visible", "layout", "border", "borderInsets"));
     
     
     
@@ -88,15 +87,15 @@ public class MdlProperties extends AbstractTableModel {
             }
 
 			// obtain property value
-			if(propName != null) {
-				Object result;
-				try {
-					result = m.invoke(bean, new Object[0]);
-					String strRes = valueToString(result);
-					map.put(propName, strRes);
-				} catch (Exception e) {} 
-			}
-		}
+            Object result;
+            try {
+                result = m.invoke(bean);
+                String strRes = valueToString(result);
+                map.put(propName, strRes);
+            } catch (Exception e) {
+
+            }
+        }
         
         if(bean instanceof JComponent) {
             Border border =((JComponent)bean).getBorder();
@@ -118,25 +117,23 @@ public class MdlProperties extends AbstractTableModel {
 	private String constraintsAsString(JComponent bean) throws Exception {
 		Container parent = bean.getParent();
         LayoutManager layout = parent.getLayout();
-        Method methGetConstraints = layout.getClass().getMethod("getConstraints", new Class[]{Component.class});
-        Object result = methGetConstraints.invoke(layout, new Object[]{bean});
+        Method methGetConstraints = layout.getClass().getMethod("getConstraints", Component.class);
+        Object result = methGetConstraints.invoke(layout, bean);
         
         if(result instanceof GridBagConstraints) {
         	GridBagConstraints gbc = (GridBagConstraints)result;
-        	
-        	String strValue =
-        	"gridx: " + gbc.gridx + ", "
-        	+ "gridy:" + gbc.gridy + ", "
-        	+ "gridwidth:" + gbc.gridwidth + ", "
-        	+ "gridheight:" + gbc.gridheight + ", "
-        	+ "weightx:" + gbc.weightx + ", "
-        	+ "weighty:" + gbc.weighty + ", "
-        	+ "anchor:" + gbc.anchor + ", "
-        	+ "fill:" + gbc.fill + ", "
-        	+ "insets:" + gbc.insets + ", "
-        	+ "ipadx:" + gbc.ipadx + ", "
-        	+ "ipady:" + gbc.ipady + "";
-        	return strValue;
+
+            return "gridx: " + gbc.gridx + ", "
+                + "gridy:" + gbc.gridy + ", "
+                + "gridwidth:" + gbc.gridwidth + ", "
+                + "gridheight:" + gbc.gridheight + ", "
+                + "weightx:" + gbc.weightx + ", "
+                + "weighty:" + gbc.weighty + ", "
+                + "anchor:" + gbc.anchor + ", "
+                + "fill:" + gbc.fill + ", "
+                + "insets:" + gbc.insets + ", "
+                + "ipadx:" + gbc.ipadx + ", "
+                + "ipady:" + gbc.ipady + "";
         }
         return "" + result;
 	}
@@ -216,7 +213,6 @@ public class MdlProperties extends AbstractTableModel {
 		} catch (Exception e) {
 			properties = new String[0][0];
 			e.printStackTrace();
-			return;
 		} finally {
 			fireTableDataChanged();
 		}

--- a/swingexplorer-core/src/main/java/sample/CheckThreadViolationRepaintManager.java
+++ b/swingexplorer-core/src/main/java/sample/CheckThreadViolationRepaintManager.java
@@ -22,12 +22,7 @@ package sample;
 
 import java.lang.ref.WeakReference;
 
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JEditorPane;
-import javax.swing.JFrame;
-import javax.swing.RepaintManager;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 
 /**
  * <p>This class is used to detect Event Dispatch Thread rule violations<br>
@@ -139,7 +134,7 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
 
     static void test() {
         JFrame frame = new JFrame("Am I on EDT?");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         frame.add(new JButton("JButton"));
         frame.pack();
         frame.setVisible(true);
@@ -149,7 +144,7 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
     //this test must pass
     static void imageUpdateTest() {
         JFrame frame = new JFrame();
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         JEditorPane editor = new JEditorPane();
         frame.setContentPane(editor);
         editor.setContentType("text/html");

--- a/swingexplorer-core/src/main/java/sample/FrmPerson.java
+++ b/swingexplorer-core/src/main/java/sample/FrmPerson.java
@@ -54,7 +54,7 @@ public class FrmPerson extends javax.swing.JFrame {
         rbnMale = new javax.swing.JRadioButton();
         rbnFemale = new javax.swing.JRadioButton();
         lblCountry = new javax.swing.JLabel();
-        cmbCountry = new javax.swing.JComboBox();
+        cmbCountry = new javax.swing.JComboBox<String>();
         lblDescription = new javax.swing.JLabel();
         btnModalDialog = new javax.swing.JButton();
         btnOwnerlessModalDialog = new javax.swing.JButton();
@@ -122,7 +122,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         lblCountry.setText("Country:");
 
-        cmbCountry.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "England", "Belgium", "France", "Spain", "Italy", "Germany" }));
+        cmbCountry.setModel(new javax.swing.DefaultComboBoxModel<String>(new String[] { "England", "Belgium", "France", "Spain", "Italy", "Germany" }));
 
         lblDescription.setFont(new java.awt.Font("Tahoma", 1, 12));
         lblDescription.setText("This is sample Swing application to demonstrate Swing Explorer");
@@ -370,7 +370,7 @@ public class FrmPerson extends javax.swing.JFrame {
     private javax.swing.JButton btnThreadViolation;
     private javax.swing.JButton btnThreadViolation2;
     private javax.swing.JButton btnThreadViolation3;
-    private javax.swing.JComboBox cmbCountry;
+    private javax.swing.JComboBox<String> cmbCountry;
     private javax.swing.ButtonGroup grpGender;
     private javax.swing.JLabel lblCountry;
     private javax.swing.JLabel lblDescription;


### PR DESCRIPTION
This refactors the code to "modernize" it for Java 8, using newer, more concise expressions for some things.

Should be no behavior changes; the new code is entirely equivalent to the old, when run under Java 8.

Refactorings done:

* Removes unnecessary explicit array creation when calling varargs methods
* Switches some for loops to foreach
* Replace pre-sized toArray() arguments with new Xxx[0]
* Replace StringBuffer with StringBuilder
* Inlined a few expressions
* Replace manual array copies with System.arraycopy
* Removed unnecessary null check on bar before foo.equals(bar)
* Remove some unnecessary null checks
* Replace JFrame.FOO with WindowConstants.FOO
* Replace instance-based static member access with class-based access
* Remove unnecessary unboxing
* Replace toString() call on arrays with Arrays.toString(...)
* Replace StringBuilder append-concatenation calls with chained append(...) calls
* Simplify some boolean expressions

Depends on #17.
