### PR TITLE
Fix Java example in naming conventions

### DIFF
--- a/docs/Code-Style.md
+++ b/docs/Code-Style.md
@@ -38,7 +38,7 @@ Example:
 
 ```java
 class Person {
-    private name;
+    private String name;
 
     public void setName(String _name) {
         name = _name;


### PR DESCRIPTION
There's a syntax error in the Java example in our Coding-Style doc. This PR fixes it.