### PR TITLE
Remove unnecessary interface "public" access modifiers

### DIFF
--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/AWTEventModel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/AWTEventModel.java
@@ -29,20 +29,20 @@ import java.beans.PropertyChangeListener;
  */
 public interface AWTEventModel {
 
-	public void setMonitoring(boolean monitoring);
+	void setMonitoring(boolean monitoring);
 	
-	public void setFilter(Filter _filter);
+	void setFilter(Filter _filter);
 	
-	public Filter getFilter();
+	Filter getFilter();
 	
-	public boolean isMonitoring();
+	boolean isMonitoring();
 	
-	public void addPropertyChangeListener(PropertyChangeListener listener);
+	void addPropertyChangeListener(PropertyChangeListener listener);
 	
-	public void removePropertyChangeListener(PropertyChangeListener listener);
+	void removePropertyChangeListener(PropertyChangeListener listener);
 	
-	public void addEventListener(AWTEventListener listener);
+	void addEventListener(AWTEventListener listener);
 	
-	public void removeEventListener(AWTEventListener listener);
+	void removeEventListener(AWTEventListener listener);
 }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/filter/FilterChangeListener.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/filter/FilterChangeListener.java
@@ -29,5 +29,5 @@ import org.swingexplorer.awt_events.Filter;
  */
 public interface FilterChangeListener extends EventListener {
 
-	public void filterChanged(Filter newFilter);
+	void filterChanged(Filter newFilter);
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/Converter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/Converter.java
@@ -28,9 +28,9 @@ import java.text.ParseException;
 public interface Converter<T> {
 
 	/** Converts text to object */ 
-	public T fromString(String strValue) throws ParseException;
+	T fromString(String strValue) throws ParseException;
 	
 	
 	/** Converts object to string */ 
-	public String toString(T value);
+	String toString(T value);
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/Property.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/Property.java
@@ -29,5 +29,5 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Property {
 
-	public String defaultValue();
+	String defaultValue();
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/PlayerListener.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/PlayerListener.java
@@ -27,12 +27,12 @@ import java.util.EventListener;
  */
 public interface PlayerListener extends EventListener {
 	
-	public void imageRendered(ImageEvent evt);
+	void imageRendered(ImageEvent evt);
 	
-	public void stateChanged(StateEvent evt);
+	void stateChanged(StateEvent evt);
 	
-	public void operationsReset(OperationResetEvent operations);
+	void operationsReset(OperationResetEvent operations);
 	
-	public void currentOperationChanged(CurrentOperationChangeEvent evt);
+	void currentOperationChanged(CurrentOperationChangeEvent evt);
 }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/idesupport/IDESupportMBean.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/idesupport/IDESupportMBean.java
@@ -31,11 +31,11 @@ public interface IDESupportMBean {
 	 * for showing right message to the user
 	 * when IDE integration is not available.
 	 */
-	public void connect();
+	void connect();
 	
 	/**
 	 * IDE plugin should call this method when
 	 * IDE is closed and connection becomes unavailable.
 	 */
-	public void disconnect();
+	void disconnect();
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/Personalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/Personalizer.java
@@ -42,7 +42,7 @@ public interface Personalizer {
 	 * @param options
 	 * @param component
 	 */
-	public void install(Options options, Component component);
+	void install(Options options, Component component);
 	
 	/**
 	 * The method is called by application before it closes
@@ -50,5 +50,5 @@ public interface Personalizer {
 	 * the Options object provided to personalizer in the install(Options, JComponent)
 	 * method.
 	 */
-	public void saveState();
+	void saveState();
 }


### PR DESCRIPTION
All method members in interfaces are inherently and implicitly public; there's no need to explicitly declare them as such.

This PR removes the unnecessary "public" modifiers from the interface definitions that have them.