### PR TITLE
Unnecessary semicolons

### DIFF
--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntArrayConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntArrayConverter.java
@@ -34,7 +34,7 @@ public class IntArrayConverter implements Converter<int[]>{
 		int count = tokens.countTokens();
 		
 		int[] result = new int[count];
-		int i = 0;;
+		int i = 0;
 		try {
 			while(tokens.hasMoreElements()) {
 				String strNumber = tokens.nextToken();


### PR DESCRIPTION
Oops; there's a typo that added an extra semicolon in `IntArrayConverter`. This PR removes it.