### PR TITLE
Refactor: Strengthen access controls on fields and methods

### DIFF
--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActDisplayComponent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActDisplayComponent.java
@@ -31,8 +31,8 @@ import javax.swing.JOptionPane;
 public class ActDisplayComponent extends RichAction {
 
 	MdlSwingExplorer model;
-    PnlComponentTree pnlComponentTree;
-	
+    private PnlComponentTree pnlComponentTree;
+
 	ActDisplayComponent(MdlSwingExplorer modelP, PnlComponentTree pnlComponentTreeP) {
 		setName("Display");
 		setTooltip("Display selected component");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActDumpAdditionTrace.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActDumpAdditionTrace.java
@@ -32,9 +32,9 @@ import org.swingexplorer.instrument.Agent;
  */
 public class ActDumpAdditionTrace extends RichAction {
 
-	PnlComponentTree pnlComponentTree;
-	MdlSwingExplorer mdlSwingExplorer;
-	
+	private PnlComponentTree pnlComponentTree;
+	private MdlSwingExplorer mdlSwingExplorer;
+
 	ActDumpAdditionTrace(MdlSwingExplorer _mdlSwingExplorer, PnlComponentTree _pnlComponentTree) {
 		setName("Dump addition trace");
 		setTooltip("<html>Dumps a stack trace<br> where the component was<br> added into container</html>");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActHelp.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActHelp.java
@@ -29,7 +29,7 @@ import javax.swing.JOptionPane;
  */
 public class ActHelp extends RichAction {
 	
-	public ActHelp() {
+	ActHelp() {
 		setName("User documentation");
 		setTooltip("User documentation");
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActHelpAbout.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActHelpAbout.java
@@ -29,9 +29,9 @@ import java.awt.event.ActionEvent;
 @SuppressWarnings("serial")
 public class ActHelpAbout extends RichAction {
 	
-	Frame owner;
+	private Frame owner;
 	
-	public ActHelpAbout(Frame ownerP) {
+	ActHelpAbout(Frame ownerP) {
 		setName("About");
 		setTooltip("About Swing Explorer");
 		owner = ownerP;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActKeyOnDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActKeyOnDisplay.java
@@ -28,8 +28,7 @@ import java.awt.event.KeyListener;
  */
 public class ActKeyOnDisplay implements KeyListener {
 
-	
-	PnlGuiDisplay display;
+	private PnlGuiDisplay display;
 	MdlSwingExplorer model;
 	
 	ActKeyOnDisplay(PnlGuiDisplay displayP, MdlSwingExplorer modelP) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActMouseClickOnDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActMouseClickOnDisplay.java
@@ -35,7 +35,7 @@ import javax.swing.JOptionPane;
  */
 public class ActMouseClickOnDisplay extends MouseAdapter {
 	
-	PnlGuiDisplay display;
+	private PnlGuiDisplay display;
 	MdlSwingExplorer model;
 	
 	ActMouseClickOnDisplay(PnlGuiDisplay displayP, MdlSwingExplorer modelP) {
@@ -65,7 +65,7 @@ public class ActMouseClickOnDisplay extends MouseAdapter {
         }
     }
     
-	void handlePressed(MouseEvent e, Component comp) {
+	private void handlePressed(MouseEvent e, Component comp) {
 		if(e.getButton() == BUTTON1) {
 			
 			int onmask = CTRL_DOWN_MASK;
@@ -95,7 +95,7 @@ public class ActMouseClickOnDisplay extends MouseAdapter {
 		}
 	}
 	
-	void doubleClick(MouseEvent e, Component comp) {
+	private void doubleClick(MouseEvent e, Component comp) {
 		if(e.getButton() == BUTTON1) {
 			try {
                 model.setDisplayedComponent(comp);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActMoveOverDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActMoveOverDisplay.java
@@ -30,7 +30,7 @@ import java.awt.event.MouseMotionListener;
  */
 public class ActMoveOverDisplay extends MouseAdapter implements MouseMotionListener  {
 	
-	PnlGuiDisplay display;
+	private PnlGuiDisplay display;
 	MdlSwingExplorer model;
 	
 	ActMoveOverDisplay(PnlGuiDisplay displayP, MdlSwingExplorer modelP) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActOpenSourceCode.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActOpenSourceCode.java
@@ -34,9 +34,9 @@ import org.swingexplorer.idesupport.IDESupport;
 public class ActOpenSourceCode extends RichAction {
 
     IDESupport ideSupport;
-    PnlPlayerControls owner;
+    private PnlPlayerControls owner;
     
-    public ActOpenSourceCode(PnlPlayerControls _owner) {
+    ActOpenSourceCode(PnlPlayerControls _owner) {
         setName("src");
         setTooltip("Open sourcecode in IDE");
         owner = _owner;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActRefresh.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActRefresh.java
@@ -50,16 +50,16 @@ import org.swingexplorer.PnlComponentTree.TreeNodeObject;
  */
 public class ActRefresh extends RichAction {
 
-	PnlComponentTree pnlComponentTree;
-    
+	private PnlComponentTree pnlComponentTree;
+
     // the fields used for detecting
     // changes in the component hierarchy
-    Timer timer;
-    HierarchyEvent lastEvent;
-    Component lastAncestor;
-    MdlSwingExplorer mdlSwingExplorer;
+    private Timer timer;
+    private HierarchyEvent lastEvent;
+    private Component lastAncestor;
+    private MdlSwingExplorer mdlSwingExplorer;
     
-	public ActRefresh(PnlComponentTree _pnlComponentTree, MdlSwingExplorer _mdlSwingExplorer) {
+	ActRefresh(PnlComponentTree _pnlComponentTree, MdlSwingExplorer _mdlSwingExplorer) {
 		setName("Refresh");
 		setTooltip("<html>Refresh tree and<br> displayed component</html>");
 		setIcon("refresh.png");
@@ -119,7 +119,7 @@ public class ActRefresh extends RichAction {
 	}
     
     
-    public void refreshTreeModel() {
+    void refreshTreeModel() {
         // reset last event and ancestor t mark
         // that refresh was performed
         lastEvent = null;
@@ -207,7 +207,7 @@ public class ActRefresh extends RichAction {
 		addChildren(root, list.toArray(new Window[list.size()]), forJDK15);		
 	}
 	
-	String getWindowTitle(Window wnd) {
+	private String getWindowTitle(Window wnd) {
 		String title = wnd.getClass().getSimpleName();
 		if(wnd instanceof Frame) {
 			title = title + "(" + ((Frame)wnd).getTitle() + ")";
@@ -217,7 +217,7 @@ public class ActRefresh extends RichAction {
 		return title;
 	}
 	
-	void addChildren(DefaultMutableTreeNode root, Window[] windows, boolean forJRE15) {
+	private void addChildren(DefaultMutableTreeNode root, Window[] windows, boolean forJRE15) {
 		for (int i = 0; i < windows.length; i++) {
 			TreeNodeObject object = new TreeNodeObject(windows[i], getWindowTitle(windows[i]));
 			DefaultMutableTreeNode child = new DefaultMutableTreeNode(object);
@@ -234,7 +234,7 @@ public class ActRefresh extends RichAction {
 		
 	}
 	
-	void addChildren(DefaultMutableTreeNode node, Container cont) {
+	private void addChildren(DefaultMutableTreeNode node, Container cont) {
 		for(int i = 0; i<cont.getComponentCount(); i++) {
 			Component comp = cont.getComponent(i);
 			
@@ -322,7 +322,7 @@ public class ActRefresh extends RichAction {
 		}
 	}
     
-	static Frame getSharedOwnerFrame() {
+	private static Frame getSharedOwnerFrame() {
 		try {
 			Method meth = SwingUtilities.class.getDeclaredMethod("getSharedOwnerFrame", new Class[]{});
 			meth.setAccessible(true);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActShowEventSource.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActShowEventSource.java
@@ -35,10 +35,10 @@ import org.swingexplorer.awt_events.PnlAwtEvents;
  */
 public class ActShowEventSource extends RichAction {
 	
-	MdlSwingExplorer mdlSwingExplorer;
-	PnlAwtEvents pnlAwtEvents;
+	private MdlSwingExplorer mdlSwingExplorer;
+	private PnlAwtEvents pnlAwtEvents;
 
-	public ActShowEventSource(MdlSwingExplorer _mdlSwingExplorer, PnlAwtEvents _pnlAwtEvents) {
+	ActShowEventSource(MdlSwingExplorer _mdlSwingExplorer, PnlAwtEvents _pnlAwtEvents) {
 		mdlSwingExplorer = _mdlSwingExplorer;
 		pnlAwtEvents = _pnlAwtEvents;
 		setName("Show event source");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -32,10 +32,10 @@ import javax.swing.tree.TreePath;
 public class ActTreeSelectionChanged implements TreeSelectionListener {
     
     MdlSwingExplorer model;
-    PnlComponentTree pnlComponentTree;
+    private PnlComponentTree pnlComponentTree;
     
     /* Creates a new instance of ActTreeSelectionChanged */
-    public ActTreeSelectionChanged(MdlSwingExplorer modelP, PnlComponentTree pnlComponentTreeP) {
+    ActTreeSelectionChanged(MdlSwingExplorer modelP, PnlComponentTree pnlComponentTreeP) {
         model = modelP;
         pnlComponentTree = pnlComponentTreeP;
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActZoomIn.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActZoomIn.java
@@ -29,12 +29,13 @@ public class ActZoomIn extends RichAction {
 
 	MdlSwingExplorer model;
 	
-	public ActZoomIn(MdlSwingExplorer modelP) {
+	ActZoomIn(MdlSwingExplorer modelP) {
 		setName("Zoom In");
 		setTooltip("Zoom In");
         setIcon("zoom_in.png");
         model = modelP;
 	}
+
 	public void actionPerformed(ActionEvent e) {
 		// 
 		double curScale = model.getDisplayScale();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActZoomOut.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActZoomOut.java
@@ -29,7 +29,7 @@ public class ActZoomOut extends RichAction {
 
 	MdlSwingExplorer model; 
 	
-	public ActZoomOut(MdlSwingExplorer model) {
+	ActZoomOut(MdlSwingExplorer model) {
 		setName("Zoom Out");
 		setTooltip("Zoom Out");
         setIcon("zoom_out.png");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedIcon.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedIcon.java
@@ -38,14 +38,14 @@ import javax.swing.Timer;
  */
 public class AnimatedIcon implements Icon {
     
-    public final Icon EMPTY_ICON = new EmptyIcon();
-    JComponent ownerComponent; 
-    Icon currentIcon = EMPTY_ICON;
+    private final Icon EMPTY_ICON = new EmptyIcon();
+    private JComponent ownerComponent;
+    private Icon currentIcon = EMPTY_ICON;
     private ArrayList<Icon> icons = new ArrayList<Icon>();
     private Dimension maxIconSize = new Dimension(0, 0);
     private Timer timer;
     private int iconNumber = 0;
-    boolean inProgress = false;
+    private boolean inProgress = false;
     
     public int getIconHeight() {
         return currentIcon.getIconHeight();
@@ -64,7 +64,7 @@ public class AnimatedIcon implements Icon {
      * Set icons to be animated.
      * @param _icons
      */
-    public void setIcons(Icon[] _icons) {
+    void setIcons(Icon[] _icons) {
         
         icons.clear();
         
@@ -87,7 +87,7 @@ public class AnimatedIcon implements Icon {
         return icons.toArray(new Icon[icons.size()]);
     }
     
-    public AnimatedIcon(JComponent _ownerComponent) {
+    AnimatedIcon(JComponent _ownerComponent) {
         ownerComponent = _ownerComponent;
         try {
             initActions();
@@ -145,7 +145,7 @@ public class AnimatedIcon implements Icon {
      * Makes progress indicator running.
      * @param _inProgress
      */
-    public void setInProgress(boolean _inProgress){
+    void setInProgress(boolean _inProgress){
         if(inProgress == _inProgress) {
             return;
         }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedLabel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/AnimatedLabel.java
@@ -39,9 +39,6 @@ import javax.swing.Timer;
 @SuppressWarnings("serial")
 public class AnimatedLabel extends JLabel {
 
-
-    
-    
     private ArrayList<Icon> icons = new ArrayList<Icon>();
     private EmptyIcon emptyIcon = new EmptyIcon();
     private Dimension maxIconSize = new Dimension(0, 0);
@@ -49,9 +46,9 @@ public class AnimatedLabel extends JLabel {
     
     private Timer timer;
     private int iconNumber = 0;
-    boolean inProgress = false;
+    private boolean inProgress = false;
     
-    public final Icon EMPTY_ICON = new EmptyIcon();
+    private final Icon EMPTY_ICON = new EmptyIcon();
 
     /**
      * Set icons to be animated.

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ColorComboBox.java
@@ -60,7 +60,7 @@ public class ColorComboBox extends JComboBox {
 		setEditable(false);
 	}
 	
-	public Color getSelectedColor() {
+	Color getSelectedColor() {
 		return (Color)getSelectedItem();
 	}
 	

--- a/swingexplorer-core/src/main/java/org/swingexplorer/DefaultIcon.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/DefaultIcon.java
@@ -31,7 +31,7 @@ import javax.swing.Icon;
  */
 public class DefaultIcon implements Icon {
     
-    public static Icon INSTANCE = new DefaultIcon();
+    static Icon INSTANCE = new DefaultIcon();
     
     /** Creates a new instance of DefaultIcon */
     private DefaultIcon() {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/DisplayableException.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/DisplayableException.java
@@ -23,9 +23,9 @@ package org.swingexplorer;
  * The exception is used to pass displayable messages through call stack
  * @author  Maxim Zakharenkov
  */
-public class DisplayableException extends Exception {
+class DisplayableException extends Exception {
 
-    public DisplayableException(String message) {
+    DisplayableException(String message) {
         super(message);
     }
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/DlgLicense.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/DlgLicense.java
@@ -49,7 +49,7 @@ public class DlgLicense extends JDialog {
 	private JButton btnClose;
 	private JScrollPane scp;
 
-	public DlgLicense(Dialog owner) {
+	private DlgLicense(Dialog owner) {
 		super(owner, true);
 		ByteArrayOutputStream strBuf = getLicenseText();
 		

--- a/swingexplorer-core/src/main/java/org/swingexplorer/FrmSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/FrmSwingExplorer.java
@@ -36,17 +36,16 @@ import javax.swing.SwingUtilities;
  */
 public class FrmSwingExplorer extends JFrame {
 
-	PnlSwingExplorer pnlSwingExplorer;
-	JMenuBar menuBar;
-	JMenu mnuHelp;
-	
-    ActHelpAbout actHelpAbout;
-    ActHelp actHelp;
+	private PnlSwingExplorer pnlSwingExplorer;
+	private JMenuBar menuBar;
+	private JMenu mnuHelp;
+
+    private ActHelpAbout actHelpAbout;
+    private ActHelp actHelp;
 	
 	Launcher application;
 	
-		
-	public FrmSwingExplorer() {
+	FrmSwingExplorer() {
 		initComponents();
 		initActions();
 	}
@@ -84,7 +83,7 @@ public class FrmSwingExplorer extends JFrame {
 		}
 	}
 	
-	void initActions() {
+	private void initActions() {
 		actHelpAbout = new ActHelpAbout(this);
         actHelp = new ActHelp();
                

--- a/swingexplorer-core/src/main/java/org/swingexplorer/GuiUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/GuiUtils.java
@@ -91,7 +91,7 @@ final public class GuiUtils {
      * @return Instance of <i>Image</i> object or <code>null</code> if
      * resource is not found.
      */
-    public static Image getImage(String resourceName) {
+    static Image getImage(String resourceName) {
         return getImage(null, resourceName);
     }
 
@@ -105,7 +105,7 @@ final public class GuiUtils {
      * @return Instance of <i>Image</i> object or <code>null</code> if
      * resource is not found.
      */
-    public static Image getImage(Class<?> _class, String resourceName) {
+    private static Image getImage(Class<?> _class, String resourceName) {
         URL resource;
         if (_class != null) {
             // Strange things happens here:
@@ -134,7 +134,7 @@ final public class GuiUtils {
      * @return Instance of <i>ImageIcon</i> object or <code>null</code> if
      * resource is not found.
      */
-    public static ImageIcon getImageIcon(String resourceName) {
+    static ImageIcon getImageIcon(String resourceName) {
         return getImageIcon(null, resourceName);
     }
 
@@ -148,7 +148,7 @@ final public class GuiUtils {
      * @return Instance of <i>Image</i> object or <code>null</code> if
      * resource is not found.
      */
-    public static ImageIcon getImageIcon(Class<?> _class, String resourceName) {
+    static ImageIcon getImageIcon(Class<?> _class, String resourceName) {
         Image image = getImage(_class, resourceName);
         if (image != null) {
             return new ImageIcon(image);
@@ -202,7 +202,7 @@ final public class GuiUtils {
      * then child is centered relatively to the whole screen.
      * @param child The component to be centered.
      */
-    public static void center(Component parent, Component child) {
+    static void center(Component parent, Component child) {
         if (parent == null) {
             center(child);
         } else {
@@ -214,7 +214,7 @@ final public class GuiUtils {
      * Centers specified component on a screen.
      * @param component The component to be centered.
      */
-    public static void center(Component component) {
+    private static void center(Component component) {
         // size will be restricted against screen size anyway
         // that's why boolean argument is false.
         // anyway this argument should not be removed - it is simply reserved
@@ -279,7 +279,7 @@ final public class GuiUtils {
     /**
      * Character <code>&amp;</code> used as prefix for a mnemonic symbol.
      */
-    public static final char AMP = '&' /**/;
+    private static final char AMP = '&' /**/;
 
     private static final char NO_MNEMONIC = (char) 0;
 
@@ -289,7 +289,7 @@ final public class GuiUtils {
      * @param text Text from where the symbols has to be extracted.
      * @return String where the symbols are extracted.
      */
-    public static String getTextWithoutMnemonic(String text) {
+    private static String getTextWithoutMnemonic(String text) {
         if (text == null) {
             return null;
         }
@@ -473,7 +473,7 @@ final public class GuiUtils {
      * of screen. When frame is closed the System.exit(0) is executed;
      * @param frame Frame to show
      */
-    public static void showDemoFrame(JFrame frame) {
+    private static void showDemoFrame(JFrame frame) {
         // Making good size and center the frame
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         frame.setSize((int) (screenSize.width / 1.5), (int) (screenSize.height / 1.5));
@@ -550,7 +550,7 @@ final public class GuiUtils {
      * @param tree
      * @return
      */
-    public static Enumeration<TreePath> getExpatnedTreePaths(JTree tree) {
+    private static Enumeration<TreePath> getExpatnedTreePaths(JTree tree) {
         TreePath pathToRoot = new TreePath(tree.getModel().getRoot());
         Enumeration<TreePath> expandPaths = tree.getExpandedDescendants(pathToRoot);
         return expandPaths;
@@ -576,7 +576,7 @@ final public class GuiUtils {
      * @param tree
      * @param expandPaths
      */
-    public static void expandTreePaths(JTree tree, Enumeration<TreePath> expandPaths) {
+    static void expandTreePaths(JTree tree, Enumeration<TreePath> expandPaths) {
         if(expandPaths != null) {
             
             DefaultMutableTreeNode root = (DefaultMutableTreeNode)tree.getModel().getRoot();
@@ -623,7 +623,7 @@ final public class GuiUtils {
      * @throws IllegalArgumentException if component does not belong to
      * this tabbed pane
      */
-    public static int getTabComponentIndex(JTabbedPane tbp, Component component) throws IllegalArgumentException {
+    static int getTabComponentIndex(JTabbedPane tbp, Component component) throws IllegalArgumentException {
         int count = tbp.getTabCount();
         for(int i = 0; i < count; i ++) {
             if(component == tbp.getComponentAt(i)) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/IconPanel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/IconPanel.java
@@ -34,9 +34,9 @@ import javax.swing.JComponent;
  */
 public class IconPanel extends JComponent {
 
-	Icon icon;
-	double scale = 1;
-	Rectangle selection;
+	private Icon icon;
+	private double scale = 1;
+	private Rectangle selection;
 	
 	public IconPanel(Icon ico) {
 		icon = ico;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/Icons.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/Icons.java
@@ -30,7 +30,7 @@ import javax.swing.Icon;
  */
 public abstract class Icons {
 
-    public static final String BASE_PATH = "resources/swingexplorer/";
+    static final String BASE_PATH = "resources/swingexplorer/";
     
     public static Icon warning() {
         return getImageIcon(BASE_PATH + "warning.png");
@@ -48,19 +48,19 @@ public abstract class Icons {
         return getImageIcon(BASE_PATH + "expanded_handler.png");
     }
     
-     public static Icon[] monitor() {
-         Icon[] icons = new Icon[16];
-         for (int i = 0; i < icons.length; i ++ ) {
-             icons[i] = getImageIcon(BASE_PATH + "monitor" + (i + 1) + ".png");
-         }
+    static Icon[] monitor() {
+        Icon[] icons = new Icon[16];
+        for (int i = 0; i < icons.length; i ++ ) {
+            icons[i] = getImageIcon(BASE_PATH + "monitor" + (i + 1) + ".png");
+        }
         return icons;
     }
      
-     public static Image appSmallImage() {
+    static Image appSmallImage() {
     	 return GuiUtils.getImage(BASE_PATH + "swex18x18.png");
      }
      
-     public static Icon appLogo() {
+    static Icon appLogo() {
     	 return getImageIcon(BASE_PATH + "logo40x40.png");
      }
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/Launcher.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/Launcher.java
@@ -48,9 +48,9 @@ public class Launcher implements Runnable {
     
     public IDESupport ideSupport;
     
-	public FrmSwingExplorer frmMain;
+	FrmSwingExplorer frmMain;
 	public PnlPlayerControls pnlPlayerControls;
-	public JDialog dlgPlayerControls;	
+	JDialog dlgPlayerControls;
 	public MdlSwingExplorer model = new MdlSwingExplorer();
     public Player player = new Player();
     

--- a/swingexplorer-core/src/main/java/org/swingexplorer/Log.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/Log.java
@@ -32,11 +32,11 @@ public class Log {
 	
 	private String category;
 	
-    public static final int LOG_NOTHING = 0;
-    public static final int LOG_ERROR = 1;
-    public static final int LOG_WARNING = 2;
-    public static final int LOG_INFO = 3;
-    public static final int LOG_DEBUG = 4;
+    private static final int LOG_NOTHING = 0;
+    private static final int LOG_ERROR = 1;
+    private static final int LOG_WARNING = 2;
+    private static final int LOG_INFO = 3;
+    private static final int LOG_DEBUG = 4;
     
     private static PrintStream logStream;
     
@@ -167,7 +167,7 @@ public class Log {
 		}
 	}
 	
-	public PrintStream getLogStream(boolean autoCreateDirectory) {
+	private PrintStream getLogStream(boolean autoCreateDirectory) {
 		if(logStream == null) {
 			
 			if(SysUtils.isLogToConsole()) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/MdlSwingExplorer.java
@@ -96,7 +96,7 @@ public class MdlSwingExplorer {
 	 * @param oldVal
 	 * @param newVal
 	 */
-	protected void fireCheckedPropertyChange(String prop, Object oldVal, Object newVal) {
+    private void fireCheckedPropertyChange(String prop, Object oldVal, Object newVal) {
 		if(oldVal != null && newVal != null && oldVal.equals(newVal)) {
 			return;
 		}
@@ -106,7 +106,7 @@ public class MdlSwingExplorer {
 		
 		firePropertyChange(prop, oldVal, newVal);
 	}
-	protected void firePropertyChange(String prop, Object oldVal, Object newVal) {
+	private void firePropertyChange(String prop, Object oldVal, Object newVal) {
 		log("Property %1$s changed\n", prop);
 		
 		// Guaranteed to return a non-null array
@@ -125,21 +125,21 @@ public class MdlSwingExplorer {
 		}
 	}
 
-	public Component getCurrentComponent() {
+	Component getCurrentComponent() {
 		return currentComponent;
 	}
 
-	public void setCurrentComponent(Component currentComponent) {
+	void setCurrentComponent(Component currentComponent) {
 		Object old = this.currentComponent;
 		this.currentComponent = currentComponent;
 		fireCheckedPropertyChange("currentComponent", old, currentComponent);
 	}
 
-	public Point getMeasurePoint1() {
+	Point getMeasurePoint1() {
 		return measurePoint1;
 	}
 
-	public void setMeasurePoint1(Point _measurePoint1) {
+	void setMeasurePoint1(Point _measurePoint1) {
 		Object old = this.measurePoint1;
 		if(_measurePoint1 != null) {
 			this.measurePoint1 = (Point)_measurePoint1.clone();
@@ -153,7 +153,7 @@ public class MdlSwingExplorer {
 		return measurePoint2;
 	}
 
-	public void setMeasurePoint2(Point _measurePoint2) {		
+	private void setMeasurePoint2(Point _measurePoint2) {
 		Object old = this.measurePoint2;
 		if(_measurePoint2 != null) {
 			this.measurePoint2 = (Point)_measurePoint2.clone();
@@ -180,7 +180,7 @@ public class MdlSwingExplorer {
 		return selectedComponents.toArray(new Component[selectedComponents.size()]);
 	}
 
-	public void addSelection(Component selection) {
+	void addSelection(Component selection) {
 		if(selectedComponents.contains(selection)) {
 			return;
 		}
@@ -196,8 +196,7 @@ public class MdlSwingExplorer {
 	 * but fires only one change event.
 	 * @param comp component to select
 	 */
-	public void setSelection(Component comp) {
-
+    void setSelection(Component comp) {
 		if(selectedComponents.size() == 1 && selectedComponents.get(0) == comp) {
 			// this one component is already selected
 			return;
@@ -211,24 +210,24 @@ public class MdlSwingExplorer {
 		firePropertyChange("selectedComponents", old, this.selectedComponents);
 	}
 	
-	public void removeSelection(Component selection) {
+	void removeSelection(Component selection) {
 		Object old = this.selectedComponents.clone();
 		this.selectedComponents.remove(selection);
 		firePropertyChange("selectedComponents", old, this.selectedComponents);
 	}
 	
-	public void clearSelection() {
+	private void clearSelection() {
 		Object old = this.selectedComponents.clone();
 		this.selectedComponents.clear();
 		firePropertyChange("selectedComponents", old, this.selectedComponents);
 	}
 
-	public Component getDisplayedComponent() {
+	Component getDisplayedComponent() {
 		return displayedComponent;
 	}
 
 	
-	public void setDisplayedComponent(Component displayedComponent) throws DisplayableException {
+	void setDisplayedComponent(Component displayedComponent) throws DisplayableException {
 
         // switching off EDT hanging events because  
 	    // component's rendering operations takes quite long time in the EDT
@@ -265,7 +264,7 @@ public class MdlSwingExplorer {
 	 * same component is passed as parameter
 	 * @param newDisplayedComponent
 	 */
-	public void setDisplayedComponentAndUpdateImage(Component newDisplayedComponent) throws DisplayableException {
+    void setDisplayedComponentAndUpdateImage(Component newDisplayedComponent) throws DisplayableException {
 		if(displayedComponent == newDisplayedComponent) {
 			updateDisplayedComponentImage();
 		} else {
@@ -273,11 +272,11 @@ public class MdlSwingExplorer {
 		}
 	}
 
-	public double getDisplayScale() {
+	double getDisplayScale() {
 		return displayScale;
 	}
 
-	public void setDisplayScale(double displayScale) {
+	void setDisplayScale(double displayScale) {
 		double old = this.displayScale;
 		this.displayScale = displayScale;
 		fireCheckedPropertyChange("displayScale", old, displayScale);
@@ -293,17 +292,17 @@ public class MdlSwingExplorer {
 		fireCheckedPropertyChange("options", old, options);
 	}
 	
-	public ImageIcon getDisplayedComponentImage() {
+	ImageIcon getDisplayedComponentImage() {
 		return displayedComponentImage;
 	}
 	
-	public void setDisplayedComponentImage(ImageIcon img) {
+	void setDisplayedComponentImage(ImageIcon img) {
 		ImageIcon oldvalue = displayedComponentImage;
 		displayedComponentImage = img;
 		fireCheckedPropertyChange("displayedComponentImage", oldvalue, displayedComponentImage);
 	}
 	
-	public void updateDisplayedComponentImage() {
+	void updateDisplayedComponentImage() {
 
 		
 		if(displayedComponent != null) {
@@ -341,7 +340,7 @@ public class MdlSwingExplorer {
 		}
 	}
 
-	public String getComponentPath(Component displayedComponent, boolean showIndex) {
+	String getComponentPath(Component displayedComponent, boolean showIndex) {
 		
 		StringBuilder buf = new StringBuilder();
 		Component comp = displayedComponent;
@@ -389,21 +388,21 @@ public class MdlSwingExplorer {
 		return -1;
 	}
 
-	public String getStatustext() {
+	String getStatustext() {
 		return statustext;
 	}
 
-	public void setStatustext(String statustext) {
+	void setStatustext(String statustext) {
 		String old = this.statustext;
 		this.statustext = statustext;
 		fireCheckedPropertyChange("statusText", old, this.statustext);
 	}
 
-	public boolean isSelected(Component comp) {
+	boolean isSelected(Component comp) {
 		return selectedComponents.contains(comp);
 	}
         
-    public void setMouseLocation(Point p) {
+    void setMouseLocation(Point p) {
 		Point old = this.mouseLocation;
 		if(p != null) {
 			this.mouseLocation = (Point)p.clone();
@@ -413,7 +412,7 @@ public class MdlSwingExplorer {
 		fireCheckedPropertyChange("mouseLocation", old, this.statustext);
 	}
   
-    public Point getMouseLocation() {
+    Point getMouseLocation() {
     	if(mouseLocation != null) {
     		return (Point)mouseLocation.clone();
     	} else {
@@ -421,7 +420,7 @@ public class MdlSwingExplorer {
     	}
     }
     
-    public Point getMouseLocationAbsolute() {
+    Point getMouseLocationAbsolute() {
     	Point loc = getMouseLocation();
     	if(loc == null) {
     		return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/Options.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/Options.java
@@ -40,7 +40,7 @@ import org.swingexplorer.beans.Property;
  */
 public class Options {
 
-	BeanSaver saver = new BeanSaver();
+	private BeanSaver saver = new BeanSaver();
 	
 	private BufferedImage componentWithoutBorderTexture = null;
 	
@@ -382,7 +382,7 @@ public class Options {
 	 * Loads options from file
 	 * file is determined by SysUtils.getOptionFilePath method
 	 */
-	public void load() {
+    void load() {
 		// load options if they exist from previous executions
         String optionFile = SysUtils.getOptionFilePath(false);
         try {
@@ -408,7 +408,7 @@ public class Options {
 	 * Saves options to file
 	 * file is determined by SysUtils.getOptionFilePath method
 	 */
-	public void save() {
+    void save() {
 		// save options
 		String optionFile = SysUtils.getOptionFilePath(true);
 		

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlAbout.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlAbout.java
@@ -55,11 +55,8 @@ import javax.swing.UIManager;
 @SuppressWarnings("serial")
 public class PnlAbout extends javax.swing.JPanel {
 	
-	
-    
     /** Creates new form PnlAbout */
-    public PnlAbout() {
-        
+    private PnlAbout() {
     	Font titleFont = UIManager.getFont("Label.font").deriveFont(20f);
     	Font copyrightFont = UIManager.getFont("Label.font").deriveFont(Font.PLAIN);
     	
@@ -121,7 +118,7 @@ public class PnlAbout extends javax.swing.JPanel {
         add(lblCopyright, BorderLayout.SOUTH);
     }
     
-    public static void openModal(Frame owner) {
+    static void openModal(Frame owner) {
 	    final JDialog dlgAbout = new JDialog(owner, "About", true);
 		
 		dlgAbout.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlComponentTree.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlComponentTree.java
@@ -121,11 +121,11 @@ public class PnlComponentTree extends javax.swing.JPanel {
     JPopupMenu popupMenu = new JPopupMenu();
     TreeSelectionListener actTreeSelectionChanged;
     
-    public void addAction(Action act) {
+    void addAction(Action act) {
         popupMenu.add(act);
     }
     
-    public void setRoot(DefaultMutableTreeNode root) {
+    void setRoot(DefaultMutableTreeNode root) {
     	// memorize expansions
     	TreePath pathToRoot = new TreePath(treAll.getModel().getRoot());
     	Enumeration<TreePath> expandPaths = treAll.getExpandedDescendants(pathToRoot);
@@ -149,7 +149,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
         enableSelectionNotification();
     }
     
-    public DefaultMutableTreeNode getRoot() {
+    DefaultMutableTreeNode getRoot() {
         return (DefaultMutableTreeNode)treAll.getModel().getRoot();
     }
    
@@ -180,7 +180,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
     	return (DefaultTreeModel)tree.getModel();
     }
     
-    public Component getSelectedComponent() {
+    Component getSelectedComponent() {
     	if(tbpTrees.getSelectedComponent() == scpTreeAll) {    	
     		return getComponent(treAll.getSelectionPath());
     	} else {
@@ -204,7 +204,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
 		repaint();
 	}
     
-    public static Component getComponent(TreePath path) {
+    static Component getComponent(TreePath path) {
 		if(path == null) {
 			return null;
 		}
@@ -253,7 +253,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
 		return paths.toArray(new TreePath[paths.size()]);
     }
     
-    public void setSelectComponents(Component[] components) {
+    private void setSelectComponents(Component[] components) {
     	log("setSelectComponents");
     	
     	// select components in All tree
@@ -292,12 +292,12 @@ public class PnlComponentTree extends javax.swing.JPanel {
         treDisplayed.getSelectionModel().addTreeSelectionListener(actTreeSelectionChanged);
     }
     
-	public void setTreeSelectionAction(TreeSelectionListener _actTreeSelectionChanged) {
+	void setTreeSelectionAction(TreeSelectionListener _actTreeSelectionChanged) {
         actTreeSelectionChanged =_actTreeSelectionChanged;
 		enableSelectionNotification();
 	}
 	
-	public void setDefaultTreeAction(final Action act) {
+	void setDefaultTreeAction(final Action act) {
 		MouseListener mouseListener = new MouseListener(act);
 		treAll.addMouseListener(mouseListener);
 		treDisplayed.addMouseListener(mouseListener);
@@ -403,9 +403,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
 		}
 	}
 
-
-	
-	void log(String msg) {
+	private void log(String msg) {
 //		System.out.println("[PnlComponentTree] " + msg);
 	}
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlGuiDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlGuiDisplay.java
@@ -145,7 +145,7 @@ public class PnlGuiDisplay extends JComponent {
 		g.dispose();
 	}
 
-	protected void paintSelection(Graphics2D g, Rectangle selRect, Insets borderInsets) {
+	private void paintSelection(Graphics2D g, Rectangle selRect, Insets borderInsets) {
 		g = (Graphics2D) g.create();
 
 		Options settings = model.getOptions();
@@ -157,7 +157,7 @@ public class PnlGuiDisplay extends JComponent {
 	}
 	
 
-	protected void paintMeasureLine(Graphics2D g, Point p1, Point p2) {
+	private void paintMeasureLine(Graphics2D g, Point p1, Point p2) {
 
 		if (p1 == null || p2 == null) {
 			return;
@@ -325,7 +325,7 @@ public class PnlGuiDisplay extends JComponent {
     }
     
 
-	protected void paintMeasurePoint(Graphics2D g, Point p, int size) {
+	private void paintMeasurePoint(Graphics2D g, Point p, int size) {
 		int halfSize = size / 2;
 		g.drawLine(p.x, p.y, p.x, p.y + halfSize);
 		g.drawLine(p.x, p.y, p.x + halfSize, p.y);
@@ -430,7 +430,7 @@ public class PnlGuiDisplay extends JComponent {
         return insets;
     }
 	
-	Point calculateLocation(Component comp) {
+	private Point calculateLocation(Component comp) {
 		
 		int x = 0;
 		int y = 0;
@@ -445,7 +445,7 @@ public class PnlGuiDisplay extends JComponent {
 		return new Point(x, y);
 	}
 	
-	public Component getDisplayedComponentAt(Point location) {
+	Component getDisplayedComponentAt(Point location) {
 		Component comp = model.getDisplayedComponent();
 		if(comp != null) {
 			Component over = SwingUtilities.getDeepestComponentAt(comp, 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlNoAgentModeMessage.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlNoAgentModeMessage.java
@@ -20,7 +20,7 @@ import javax.swing.JOptionPane;
 public class PnlNoAgentModeMessage extends javax.swing.JPanel {
     
     /** Creates new form PnlNoAgentModeMessage */
-    public PnlNoAgentModeMessage() {
+    private PnlNoAgentModeMessage() {
         initComponents();
         lblMessage.setText("<html> This functionality is available only when application<br>" +
         						   "is executed with instrumentation agent!<br> " +
@@ -90,9 +90,9 @@ public class PnlNoAgentModeMessage extends javax.swing.JPanel {
     
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    javax.swing.JButton btnCopy;
-    javax.swing.JLabel lblMessage;
-    javax.swing.JTextArea txaCommand;
+    private javax.swing.JButton btnCopy;
+    private javax.swing.JLabel lblMessage;
+    private javax.swing.JTextArea txaCommand;
     // End of variables declaration//GEN-END:variables
     
     

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlOptions.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlOptions.java
@@ -146,19 +146,19 @@ public class PnlOptions extends javax.swing.JPanel {
     
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    javax.swing.JButton btnReset;
-    javax.swing.JCheckBox chbDisplayPreferredSize;
-    org.swingexplorer.ColorComboBox cmbComponentIncludingBorderColor;
-    org.swingexplorer.ColorComboBox cmbComponentWithoutBorderColor;
-    org.swingexplorer.ColorComboBox cmbPreferredSizeColor;
-    javax.swing.JLabel lblBoundaryColors;
-    javax.swing.JLabel lblComponentWithBorder;
-    javax.swing.JLabel lblComponentWithoutBorder;
-    javax.swing.JLabel lblPreferredSize;
+    private javax.swing.JButton btnReset;
+    private javax.swing.JCheckBox chbDisplayPreferredSize;
+    private org.swingexplorer.ColorComboBox cmbComponentIncludingBorderColor;
+    private org.swingexplorer.ColorComboBox cmbComponentWithoutBorderColor;
+    private org.swingexplorer.ColorComboBox cmbPreferredSizeColor;
+    private javax.swing.JLabel lblBoundaryColors;
+    private javax.swing.JLabel lblComponentWithBorder;
+    private javax.swing.JLabel lblComponentWithoutBorder;
+    private javax.swing.JLabel lblPreferredSize;
     // End of variables declaration//GEN-END:variables
     
-    Options options;
-    ItemListenerImpl itemListener = new ItemListenerImpl();
+    private Options options;
+    private ItemListenerImpl itemListener = new ItemListenerImpl();
     
     
     public void setOptions(Options _options) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlPlayerControls.java
@@ -218,21 +218,21 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     private javax.swing.JSpinner spinner;
     // End of variables declaration//GEN-END:variables
     
-    boolean blockEventsFromControls = true;
+    private boolean blockEventsFromControls = true;
     Player player;
-    PlayerListener listener = new PlayerListenerImpl();
-    OperationListModel mdlOperations = new OperationListModel();
+    private PlayerListener listener = new PlayerListenerImpl();
+    private OperationListModel mdlOperations = new OperationListModel();
     
-    ActPlay actPlay = new ActPlay();
-    ActToStart actToStart = new ActToStart();
-    ActToEnd actToEnd = new ActToEnd();
-    ActPause actPause = new ActPause();
-    ActPlayStep actPlayStep = new ActPlayStep();
-    ActPlayStepBack actPlayStepBack = new ActPlayStepBack();
-    ActDumpStackTrace actDumpStackTrace = new ActDumpStackTrace();
-    ActOpenSourceCode actOpenSourceCode;
+    private ActPlay actPlay = new ActPlay();
+    private ActToStart actToStart = new ActToStart();
+    private ActToEnd actToEnd = new ActToEnd();
+    private ActPause actPause = new ActPause();
+    private ActPlayStep actPlayStep = new ActPlayStep();
+    private ActPlayStepBack actPlayStepBack = new ActPlayStepBack();
+    private ActDumpStackTrace actDumpStackTrace = new ActDumpStackTrace();
+    private ActOpenSourceCode actOpenSourceCode;
     
-    void initActions() {
+    private void initActions() {
     	btnPlayPause.setAction(actPlay);    	
     	btnToStart.setAction(actToStart);
     	btnPlayStep.setAction(actPlayStep);
@@ -245,7 +245,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
         btnSrc.setAction(actOpenSourceCode);
     }
     
-    public void setIDESupport(IDESupport _ideSupport) {
+    void setIDESupport(IDESupport _ideSupport) {
         actOpenSourceCode.ideSupport = _ideSupport;
     }
     
@@ -354,7 +354,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
 
     	Operation[] operations = new Operation[0];
 
-    	public void setOperations(Operation[] operationsP) {
+    	void setOperations(Operation[] operationsP) {
     		
     		if(operationsP == null) {
     			operationsP = new Operation[0];

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlSelectionProperties.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlSelectionProperties.java
@@ -19,9 +19,9 @@ import org.swingexplorer.properties.PnlPropertySheet;
  */
 public class PnlSelectionProperties extends javax.swing.JPanel {
 	
-	PnlPropertySheet pnlPropertySheet;
+	private PnlPropertySheet pnlPropertySheet;
     MdlSwingExplorer model;
-    ModelListener modelListener = new ModelListener();
+    private ModelListener modelListener = new ModelListener();
 	
     /** Creates new form PnlSelectionProperties */
     public PnlSelectionProperties() {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlStatusBar.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlStatusBar.java
@@ -85,7 +85,7 @@ public class PnlStatusBar extends javax.swing.JPanel {
     // End of variables declaration//GEN-END:variables
     
     MdlSwingExplorer model;
-    ModelListener modelListener = new ModelListener();
+    private ModelListener modelListener = new ModelListener();
     
     public void setModel(MdlSwingExplorer model) {
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
@@ -49,7 +49,7 @@ import org.swingexplorer.graphics.StateEvent;
 public class PnlSwingExplorer extends javax.swing.JPanel {
     
     /** Creates new form PnlSwingExplorer */
-    public PnlSwingExplorer() {
+    PnlSwingExplorer() {
     	initComponents();
         sppMain.setName("sppMain");
         sppRight.setName("sppRight");
@@ -247,30 +247,29 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
     // End of variables declaration//GEN-END:variables
     
     
-    AnimatedIcon icoEventMonitoring;
-    AnimatedIcon icoEDTMonitoring;
+    private AnimatedIcon icoEventMonitoring;
+    private AnimatedIcon icoEDTMonitoring;
     
     Launcher application;
     
-    ModelListener listener = new ModelListener();
-    PlayerListener playerListener = new PlayerListenerImpl();
+    private ModelListener listener = new ModelListener();
+    private PlayerListener playerListener = new PlayerListenerImpl();
     
-    JComboBox  cmbScale = new JComboBox();
+    private JComboBox cmbScale = new JComboBox();
     
     ActRefresh actRefresh;
-    ActDisplayComponent actDisplayComponent;
-    ActDumpAdditionTrace actTraceComponentAddition;
-    ActTreeSelectionChanged actTreeSelectionChanged;
-    ActZoomIn actZoomIn;
-    ActZoomOut actZoomOut;
-    ActMoveOverDisplay actMoveOverDisplay;
-    ActMouseClickOnDisplay actClickOnDisplay;
-    ActKeyOnDisplay actKeyOnDisplay;
-    ActDisplayTopContainer actDisplayTopContainer;
-    ActDisplayParent actDisplayParent;
-    
-    
-    void initActions() {
+    private ActDisplayComponent actDisplayComponent;
+    private ActDumpAdditionTrace actTraceComponentAddition;
+    private ActTreeSelectionChanged actTreeSelectionChanged;
+    private ActZoomIn actZoomIn;
+    private ActZoomOut actZoomOut;
+    private ActMoveOverDisplay actMoveOverDisplay;
+    private ActMouseClickOnDisplay actClickOnDisplay;
+    private ActKeyOnDisplay actKeyOnDisplay;
+    private ActDisplayTopContainer actDisplayTopContainer;
+    private ActDisplayParent actDisplayParent;
+
+    private void initActions() {
     	actRefresh = new ActRefresh(pnlComponentTree, application.model);
         pnlComponentTree.addAction(actRefresh);
         
@@ -394,7 +393,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
 		}
     }
     
-    public void addAction(RichAction act) {
+    private void addAction(RichAction act) {
     	tlbMain.addActionEx(act);
     	act.setApplication(application);
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleButton.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleButton.java
@@ -31,14 +31,14 @@ import javax.swing.JToggleButton;
  */
 public class RichToggleButton extends JToggleButton {
 
-	SelectionStateListener selectionStateListener;
+	private SelectionStateListener selectionStateListener;
 	
 	
-	public RichToggleButton() {
+	private RichToggleButton() {
 		selectionStateListener = new SelectionStateListener();
 	}
 	
-	public RichToggleButton(Action a) {
+	RichToggleButton(Action a) {
 		this();
 		setAction(a);
 	}
@@ -53,7 +53,7 @@ public class RichToggleButton extends JToggleButton {
 		}
 	}
 	
-	public void setToggleAction(RichToggleAction newAction) {
+	private void setToggleAction(RichToggleAction newAction) {
 		if(newAction == getAction()) {
 			return;
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/RichToolbar.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/RichToolbar.java
@@ -35,7 +35,7 @@ import org.swingexplorer.plaf.CustomButtonUI;
  */
 public class RichToolbar extends JToolBar {
 
-	public AbstractButton addActionEx(Action a) {
+	AbstractButton addActionEx(Action a) {
 		String text = a != null ? (String) a.getValue(Action.NAME) : null;
 		Icon icon = a != null ? (Icon) a.getValue(Action.SMALL_ICON) : null;
 		boolean enabled = a != null ? a.isEnabled() : true;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/SysUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/SysUtils.java
@@ -32,20 +32,20 @@ import java.net.URL;
  */
 public abstract class SysUtils {
 	
-	public static final String KEY_SHOW_EXPLORER_WINDOW = "swex.showwin";
-    public static final String KEY_LOG_OPTIONS = "swex.log";
-    public static final String KEY_LOG_CONSOLE = "swex.log.console";
-    public static final String KEY_MONITOR_EDT_VIOLATIONS = "swex.vmonitor";
-    public static final String KEY_MONITOR_EDT_HANGS = "swex.hmonitor";
-    public static final String KEY_MONITOR_EDT_EXCEPTIONS = "swex.emonitor";
-    public static final String KEY_MANAGEMENT_PORT = "swex.mport";
+	private static final String KEY_SHOW_EXPLORER_WINDOW = "swex.showwin";
+    private static final String KEY_LOG_OPTIONS = "swex.log";
+    private static final String KEY_LOG_CONSOLE = "swex.log.console";
+    private static final String KEY_MONITOR_EDT_VIOLATIONS = "swex.vmonitor";
+    private static final String KEY_MONITOR_EDT_HANGS = "swex.hmonitor";
+    private static final String KEY_MONITOR_EDT_EXCEPTIONS = "swex.emonitor";
+    private static final String KEY_MANAGEMENT_PORT = "swex.mport";
 
 	
 	/**
 	 * Show explorer window in the tree or not
 	 * @return
 	 */
-	public static boolean isShowExplorerWindow() {
+	static boolean isShowExplorerWindow() {
 		return getBoolean(KEY_SHOW_EXPLORER_WINDOW);
 	}
     
@@ -53,7 +53,7 @@ public abstract class SysUtils {
      * Checks if EDT violations should be monitored immediately
      * after program is started and resets the flag fo false.
      */ 
-    public static boolean isMonitorEDTViolationsAndReset() {
+    static boolean isMonitorEDTViolationsAndReset() {
         boolean res = getBoolean(KEY_MONITOR_EDT_VIOLATIONS);
         System.getProperties().remove(KEY_MONITOR_EDT_VIOLATIONS);
         return res;
@@ -67,19 +67,19 @@ public abstract class SysUtils {
      * Checks if EDT hangs should be monitored immediately
      * after program is started and resets the flag fo false.
      */
-    public static boolean isMonitorEDTHangsAndReset() {
+    static boolean isMonitorEDTHangsAndReset() {
         boolean res = getBoolean(KEY_MONITOR_EDT_HANGS);
         System.getProperties().remove(KEY_MONITOR_EDT_HANGS);
         return res;
     }
 
-    public static boolean isMonitorEDTExceptionsAndReset() {
+    static boolean isMonitorEDTExceptionsAndReset() {
         boolean res = getBoolean(KEY_MONITOR_EDT_EXCEPTIONS);
         System.getProperties().remove(KEY_MONITOR_EDT_EXCEPTIONS);
         return res;
     }
     
-    public static String getApplicationVersion() {
+    static String getApplicationVersion() {
         return SysUtils.class.getPackage().getImplementationVersion();
     }
     
@@ -118,7 +118,7 @@ public abstract class SysUtils {
 	 * @param strUri
 	 * @return true if operation succeded and false if not
 	 */
-	public static boolean openBrowser(String strUri) {
+	static boolean openBrowser(String strUri) {
         
 		try {
 	        Desktop.getDesktop().browse(new URL(strUri).toURI());
@@ -135,7 +135,7 @@ public abstract class SysUtils {
      * not exist
 	 * @return full path
 	 */
-	public static String getHomeDirectory(boolean autoCreate) {
+	static String getHomeDirectory(boolean autoCreate) {
 
 		// the exactly same implementation of this method is
 		// also presented in the both in the SysUtils class 
@@ -162,7 +162,7 @@ public abstract class SysUtils {
 		return strDir;
 	}
 	
-	public static String getOptionFilePath(boolean autoCreateDirectory) {
+	static String getOptionFilePath(boolean autoCreateDirectory) {
 		String dir = getHomeDirectory(autoCreateDirectory);
 		return dir + "/options.properties";
 	}
@@ -172,7 +172,7 @@ public abstract class SysUtils {
 	 * Determines if logging options (levels, categories).
 	 * @return
 	 */
-	public static String getLogOptions() {
+	static String getLogOptions() {
 		return System.getProperty(KEY_LOG_OPTIONS);
 	}
 	
@@ -180,7 +180,7 @@ public abstract class SysUtils {
 	 * Determines if logging to console should be done instead of file.
 	 * @return
 	 */
-	public static boolean isLogToConsole() {
+	static boolean isLogToConsole() {
 		return Boolean.getBoolean(KEY_LOG_CONSOLE);
 	}
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/NoWrapEditorKit.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/NoWrapEditorKit.java
@@ -36,7 +36,7 @@ import javax.swing.text.html.HTMLEditorKit.HTMLFactory;
  */
 public class NoWrapEditorKit extends HTMLEditorKit {
 
-    ViewFactory defaultFactory=new WrapColumnFactory();
+    private ViewFactory defaultFactory=new WrapColumnFactory();
     public ViewFactory getViewFactory() {
         return defaultFactory;
     }
@@ -53,7 +53,7 @@ class WrapColumnFactory extends HTMLFactory {
 }
 
 class NoWrapParagraphView extends ParagraphView {
-    public NoWrapParagraphView(Element elem) {
+    NoWrapParagraphView(Element elem) {
         super(elem);
     }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/PnlAdditionTrace.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/PnlAdditionTrace.java
@@ -76,8 +76,8 @@ public class PnlAdditionTrace extends javax.swing.JPanel {
     
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    javax.swing.JScrollPane scpTrace;
-    javax.swing.JEditorPane txtTrace;
+    private javax.swing.JScrollPane scpTrace;
+    private javax.swing.JEditorPane txtTrace;
     // End of variables declaration//GEN-END:variables
 
     private void initActions() {
@@ -86,9 +86,9 @@ public class PnlAdditionTrace extends javax.swing.JPanel {
 	}
 
     
-    MdlSwingExplorer model;
-    ModelListener modelListener = new ModelListener();
-    ActOpenSourceCode actOpenSourceCode;
+    private MdlSwingExplorer model;
+    private ModelListener modelListener = new ModelListener();
+    private ActOpenSourceCode actOpenSourceCode;
     
 	public void setModel(MdlSwingExplorer _model) {
 		model = _model;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActClearEvents.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActClearEvents.java
@@ -27,11 +27,11 @@ import org.swingexplorer.RichAction;
 /**
  * @author Maxim Zakharenkov
  */
-public class ActClearEvents extends RichAction {
+class ActClearEvents extends RichAction {
 
-    PnlAwtEvents owner;
+    private PnlAwtEvents owner;
 	
-	public ActClearEvents(PnlAwtEvents _owner) {
+	ActClearEvents(PnlAwtEvents _owner) {
         owner = _owner;
 		setName("Clear");
 		setTooltip("Clear events");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventFilterChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventFilterChanged.java
@@ -30,8 +30,8 @@ import org.swingexplorer.awt_events.filter.PnlEventFilter;
  */
 public class ActEventFilterChanged implements ItemListener {
 
-	PnlEventFilter owner;
-	
+	private PnlEventFilter owner;
+
 	public ActEventFilterChanged(PnlEventFilter _owner) {
 		owner = _owner;
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventSelected.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventSelected.java
@@ -28,9 +28,9 @@ import javax.swing.event.ListSelectionListener;
  */
 public class ActEventSelected implements ListSelectionListener {
 
-	PnlAwtEvents owner;
+	private PnlAwtEvents owner;
 	
-	public ActEventSelected(PnlAwtEvents _owner) {
+	ActEventSelected(PnlAwtEvents _owner) {
 		owner = _owner;
 	}
 	

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActShowFilter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActShowFilter.java
@@ -45,18 +45,17 @@ import org.swingexplorer.awt_events.filter.PnlEventFilter;
 public class ActShowFilter extends RichAction {
 
 	
-	PnlAwtEvents owner;
+	private PnlAwtEvents owner;
 	JPopupMenu popup;
 	boolean selected = false;
-    JDialog dlg;
+    private JDialog dlg;
 
-	public ActShowFilter(PnlAwtEvents _owner) {
+	ActShowFilter(PnlAwtEvents _owner) {
 		owner =_owner;
 		setName("Filter");
 
         
 	}
-	
 	
 	public void actionPerformed(ActionEvent e) {
         if(dlg == null) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStartEventMonitoring.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStartEventMonitoring.java
@@ -31,7 +31,7 @@ import org.swingexplorer.RichAction;
  */
 public class ActStartEventMonitoring extends RichAction {
 
-	AWTEventModel model;
+	private AWTEventModel model;
 	
 	ActStartEventMonitoring(AWTEventModel modelP) {
 		setTooltip("Start event monitoring");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStopEventMonitoring.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStopEventMonitoring.java
@@ -31,7 +31,7 @@ import org.swingexplorer.RichAction;
  */
 public class ActStopEventMonitoring extends RichAction {
 
-	AWTEventModel model;
+	private AWTEventModel model;
 	
 	ActStopEventMonitoring(AWTEventModel modelP) {
 		setTooltip("Stop event monitoring");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/LocalAWTEventModel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/LocalAWTEventModel.java
@@ -39,15 +39,15 @@ import javax.swing.SwingUtilities;
  */
 public class LocalAWTEventModel implements AWTEventModel {
 
-	ArrayList<AWTEventListener> listeners = new ArrayList<AWTEventListener>();
-	Dispatcher dispatcher = new Dispatcher();
-	Component owner;
-	Window rootContainer;
-	boolean monitoring;
-	PropertyChangeSupport changeSupport;
-	Filter filter;
+	private ArrayList<AWTEventListener> listeners = new ArrayList<AWTEventListener>();
+	private Dispatcher dispatcher = new Dispatcher();
+	private Component owner;
+	private Window rootContainer;
+	private boolean monitoring;
+	private PropertyChangeSupport changeSupport;
+	private Filter filter;
 	
-	public LocalAWTEventModel(Component _owner) {
+	LocalAWTEventModel(Component _owner) {
 		owner = _owner;
 		filter = new Filter();
 	}
@@ -90,7 +90,7 @@ public class LocalAWTEventModel implements AWTEventModel {
         }
     }
 	
-	protected void firePropertyChanged(String propertyName, Object oldValue, Object newValue) {
+	private void firePropertyChanged(String propertyName, Object oldValue, Object newValue) {
 		if(changeSupport != null) {
 			changeSupport.firePropertyChange(propertyName, oldValue, newValue);
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/MdlEvents.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/MdlEvents.java
@@ -32,8 +32,8 @@ import javax.swing.table.AbstractTableModel;
  */
 public class MdlEvents extends AbstractTableModel {
 
-	ArrayList<AWTEvent> events = new ArrayList<AWTEvent>(); 
-	Column[] columns = new Column[] {
+	private ArrayList<AWTEvent> events = new ArrayList<AWTEvent>();
+	private Column[] columns = new Column[] {
             new ColParamString(),
             new ColEventSource()
 	};
@@ -114,7 +114,7 @@ public class MdlEvents extends AbstractTableModel {
 		}
 	}
 	
-	public void addEvent(AWTEvent evt) {
+	void addEvent(AWTEvent evt) {
 		events.add(evt);
 		int insRow = events.size() - 1;
 		fireTableRowsInserted(insRow, insRow);
@@ -142,7 +142,7 @@ public class MdlEvents extends AbstractTableModel {
 		return columns[columnIndex].getValue(rowIndex);
 	}
 
-	public AWTEvent getEvent(int row) {
+	AWTEvent getEvent(int row) {
 		if(events.size() <= row || row < 0) {
 			return null;
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/PnlAwtEvents.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/PnlAwtEvents.java
@@ -63,7 +63,7 @@ public class PnlAwtEvents extends javax.swing.JPanel {
         header.setUI(new CustomTableHeaderUI());
     }
     
-    void initActions() {
+    private void initActions() {
     	actStartEventMonitoring = new ActStartEventMonitoring(eventModel);
     	actStopEventMonitoring = new ActStopEventMonitoring(eventModel);
     	
@@ -100,14 +100,14 @@ public class PnlAwtEvents extends javax.swing.JPanel {
 		return mdlTblEvents.getEvent(selRow);
     }
     
-    public void addEvent(AWTEvent evt) {    	
+    private void addEvent(AWTEvent evt) {
     	mdlTblEvents.addEvent(evt);
     	int rowNo = mdlTblEvents.getRowCount() - 1;
     	mdlTblEvents.fireTableRowsInserted(rowNo, rowNo);
         tblEvents.scrollRectToVisible(tblEvents.getCellRect(rowNo, 1, true));
     }
     
-    public void clearEvents() {
+    void clearEvents() {
         mdlTblEvents.clear();
     }
     
@@ -115,7 +115,7 @@ public class PnlAwtEvents extends javax.swing.JPanel {
         
     }
     
-    public void setEventModel(AWTEventModel modelP) {
+    private void setEventModel(AWTEventModel modelP) {
     	if(eventModel != null) {
     		eventModel.removeEventListener(modelListener);
     	}
@@ -246,13 +246,13 @@ public class PnlAwtEvents extends javax.swing.JPanel {
     private javax.swing.JTextField txtStatus;
     // End of variables declaration//GEN-END:variables
     
-    MdlEvents mdlTblEvents = new MdlEvents();
-    AWTEventModel eventModel;
-    AWTEventListener modelListener = new ModelListener();
-    ActStartEventMonitoring actStartEventMonitoring;
-    ActStopEventMonitoring actStopEventMonitoring;
-    ActClearEvents actClearEvents;
-    RichAction actShowEventSource;
-    ActShowFilter actShowFilter;
+    private MdlEvents mdlTblEvents = new MdlEvents();
+    private AWTEventModel eventModel;
+    private AWTEventListener modelListener = new ModelListener();
+    private ActStartEventMonitoring actStartEventMonitoring;
+    private ActStopEventMonitoring actStopEventMonitoring;
+    private ActClearEvents actClearEvents;
+    private RichAction actShowEventSource;
+    private ActShowFilter actShowFilter;
 }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/BeanSaver.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/BeanSaver.java
@@ -58,7 +58,7 @@ public class BeanSaver {
 		load(bean, props, false);
 	}
 	
-	public void load(Object bean, Map<String, String> props, boolean ignoreError) {
+	private void load(Object bean, Map<String, String> props, boolean ignoreError) {
 		resetToDefaults(bean);
 		for(Object property : props.keySet()) {
 			String strProperty = (String)property;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActClear.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActClear.java
@@ -27,11 +27,11 @@ import org.swingexplorer.RichAction;
  *
  * @author  Maxim Zakharenkov
  */
-public class ActClear extends RichAction {
+class ActClear extends RichAction {
 
-    PnlEDTMonitor owner;
+    private PnlEDTMonitor owner;
     
-    public ActClear(PnlEDTMonitor _owner) {
+    ActClear(PnlEDTMonitor _owner) {
         owner = _owner;
     }
     

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActOpenSourceCode.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActOpenSourceCode.java
@@ -25,7 +25,7 @@ import org.swingexplorer.idesupport.IDESupport;
  *
  * @author  Maxim Zakharenkov
  */
-public class ActOpenSourceCode {
+class ActOpenSourceCode {
 
 	IDESupport ideSupport;
 	private PnlEDTMonitor owner;
@@ -34,7 +34,7 @@ public class ActOpenSourceCode {
 		owner = _owner;
 	}
 	
-	public void openSourceCode(String link) {
+	void openSourceCode(String link) {
 		String[] params = link.split(":");
 		ideSupport.requestCheckedOpenSourceCode(params[0], Integer.parseInt(params[1]), owner);
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActTrace.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActTrace.java
@@ -32,9 +32,9 @@ import org.swingexplorer.instrument.Problem;
  */
 public class ActTrace extends RichAction {
 
-    PnlEDTMonitor owner;
+    private PnlEDTMonitor owner;
     
-    public ActTrace(PnlEDTMonitor _owner) {
+    ActTrace(PnlEDTMonitor _owner) {
         owner = _owner;
     }
     

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/EDTDebugQueue.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/EDTDebugQueue.java
@@ -62,9 +62,9 @@ public class EDTDebugQueue extends EventQueue {
         private final LinkedList<DispatchInfo> dispatches = new LinkedList<DispatchInfo>();
   
         
-        static long minimalMonitoredHangTime = 1000;
-        static EDTDebugQueue instance = new EDTDebugQueue();
-        static ProblemListener problemListener;
+        private static long minimalMonitoredHangTime = 1000;
+        private static EDTDebugQueue instance = new EDTDebugQueue();
+        private static ProblemListener problemListener;
         
         // this flag is used for temporary switching off
         // events about hangs. It is useful fow SwingExplorer
@@ -75,10 +75,10 @@ public class EDTDebugQueue extends EventQueue {
         public static boolean disableHangEvents = false;
         
         
-        public static boolean monitorHangs = false;
-        public static boolean monitorExceptions = false;
+        static boolean monitorHangs = false;
+        static boolean monitorExceptions = false;
         
-        public static void setProblemListener(ProblemListener _problemListener) {
+        static void setProblemListener(ProblemListener _problemListener) {
             problemListener = _problemListener;
         }
         
@@ -91,11 +91,11 @@ public class EDTDebugQueue extends EventQueue {
             Toolkit.getDefaultToolkit().getSystemEventQueue().push(instance);
         }
 
-        public static long getMinimalMonitoredHangTime() {
+        static long getMinimalMonitoredHangTime() {
             return minimalMonitoredHangTime;
         }
 
-        public static void setMinimalMonitoredHangTime(long _minimalMonitoredHangTime) {
+        static void setMinimalMonitoredHangTime(long _minimalMonitoredHangTime) {
             minimalMonitoredHangTime = _minimalMonitoredHangTime;
         }
         
@@ -117,11 +117,11 @@ public class EDTDebugQueue extends EventQueue {
             // The last time in milliseconds at which we saw a dispatch on the above thread.
             private long lastDispatchTimeMillis = System.currentTimeMillis();
     
-            public DispatchInfo() {
+            DispatchInfo() {
                 // All initialization is done by the field initializers.
             }
     
-            public void checkForHang() {
+            void checkForHang() {
                 if (timeSoFar() > getMinimalMonitoredHangTime()) {
                     examineHang();
                 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/MdlEDTMonitor.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/MdlEDTMonitor.java
@@ -35,18 +35,18 @@ import org.swingexplorer.util.ListenerSupport;
  */
 public class MdlEDTMonitor {
 
-    boolean monitorViolations;
+    private boolean monitorViolations;
     
-    PropertyChangeSupport propChangeSupport = new PropertyChangeSupport(this);
-    ProblemListenerRedispatcher problemListenerRedispatcher = new ProblemListenerRedispatcher();
-    ListenerSupport<ProblemListener> listenerSupport = new ListenerSupport<ProblemListener>(ProblemListener.class);
+    private PropertyChangeSupport propChangeSupport = new PropertyChangeSupport(this);
+    private ProblemListenerRedispatcher problemListenerRedispatcher = new ProblemListenerRedispatcher();
+    private ListenerSupport<ProblemListener> listenerSupport = new ListenerSupport<ProblemListener>(ProblemListener.class);
     
     
-    public MdlEDTMonitor() {
+    MdlEDTMonitor() {
         EDTDebugQueue.setProblemListener(problemListenerRedispatcher);
     }
     
-    public boolean isViolationMonitoringAvailable() {
+    boolean isViolationMonitoringAvailable() {
         return Agent.isInstrumented();
     }
         
@@ -62,11 +62,11 @@ public class MdlEDTMonitor {
         propChangeSupport.firePropertyChange("monitorViolations", old, monitorViolations);
     }
 
-    public int getMinimalMonitoredHangTime() {
+    int getMinimalMonitoredHangTime() {
         return (int)EDTDebugQueue.getMinimalMonitoredHangTime();
     }
 
-    public void setMinimalMonitoredHangTime(int _minimalMonitoredHangTime) {
+    void setMinimalMonitoredHangTime(int _minimalMonitoredHangTime) {
         long old = EDTDebugQueue.getMinimalMonitoredHangTime();
         EDTDebugQueue.setMinimalMonitoredHangTime(_minimalMonitoredHangTime);
         propChangeSupport.firePropertyChange("minimalMonitoredHangTime", old, _minimalMonitoredHangTime);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/PnlEDTMonitor.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/PnlEDTMonitor.java
@@ -117,7 +117,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
     }
     
     
-    String getLink(Point p) {
+    private String getLink(Point p) {
     	int row = treProblems.getRowForLocation(p.x, p.y);
         if(row == -1) {
         	return null;
@@ -293,23 +293,23 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
     
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    javax.swing.JButton btnClear;
-    javax.swing.JButton btnTrace;
-    javax.swing.JCheckBox chbEDTExceptions;
-    javax.swing.JCheckBox chbEDTViolations;
-    javax.swing.JCheckBox chbHangs;
-    javax.swing.JScrollPane scpProblems;
-    javax.swing.JSpinner spnDelay;
-    javax.swing.JTree treProblems;
+    private javax.swing.JButton btnClear;
+    private javax.swing.JButton btnTrace;
+    private javax.swing.JCheckBox chbEDTExceptions;
+    private javax.swing.JCheckBox chbEDTViolations;
+    private javax.swing.JCheckBox chbHangs;
+    private javax.swing.JScrollPane scpProblems;
+    private javax.swing.JSpinner spnDelay;
+    private javax.swing.JTree treProblems;
     // End of variables declaration//GEN-END:variables
     
-    ActClear actClear;
-    ActTrace actTrace;
-    ActOpenSourceCode actOpenSourceCode;
-    MdlEDTMonitor mdlMonitor;
-    DefaultTreeCellRenderer renderer;
-    ModelPropertyChangeListener modelPropChangeListener = new ModelPropertyChangeListener();
-    ProblemListenerImpl problemListener = new ProblemListenerImpl();
+    private ActClear actClear;
+    private ActTrace actTrace;
+    private ActOpenSourceCode actOpenSourceCode;
+    private MdlEDTMonitor mdlMonitor;
+    private DefaultTreeCellRenderer renderer;
+    private ModelPropertyChangeListener modelPropChangeListener = new ModelPropertyChangeListener();
+    private ProblemListenerImpl problemListener = new ProblemListenerImpl();
     
     
     public void setModel(MdlEDTMonitor _model) {
@@ -328,7 +328,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
     }
     
     
-    public void addProblem(Problem problem){
+    void addProblem(Problem problem){
         DefaultMutableTreeNode root = (DefaultMutableTreeNode) treProblems.getModel().getRoot();
         
         // adding problem
@@ -348,14 +348,14 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
         GuiUtils.notifyTreeChanged(treProblems);
     }
     
-    public void clearProblems() {
+    void clearProblems() {
         DefaultMutableTreeNode root = (DefaultMutableTreeNode) treProblems.getModel().getRoot();
         root.removeAllChildren();
         GuiUtils.notifyTreeChanged(treProblems);
     }
 
     /** Returns array of problems selected */
-    public Problem[] getSelectedProblems() {
+    Problem[] getSelectedProblems() {
         TreePath[] paths = treProblems.getSelectionPaths();
         if(paths == null) {
             return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/CurrentOperationChangeEvent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/CurrentOperationChangeEvent.java
@@ -27,10 +27,10 @@ import java.util.EventObject;
  */
 public class CurrentOperationChangeEvent extends EventObject {
 
-	Operation currentOperation;
-	Operation oldOperation;
+	private Operation currentOperation;
+	private Operation oldOperation;
 	
-	public CurrentOperationChangeEvent(Player source, Operation currentOp, Operation oldOp) {
+	CurrentOperationChangeEvent(Player source, Operation currentOp, Operation oldOp) {
 		super(source);
 		currentOperation = currentOp;
 		oldOperation = oldOp;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/FrmInterpret.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/FrmInterpret.java
@@ -43,12 +43,12 @@ import java.util.concurrent.Executors;
  */
 public class FrmInterpret extends Frame {
 
-	Button btnStep = new Button("Step");
-	Button btnRun = new Button("Run");
-	Component drawing = new Component() {};
-	XGraphics xgraphics;
+	private Button btnStep = new Button("Step");
+	private Button btnRun = new Button("Run");
+	private Component drawing = new Component() {};
+	private XGraphics xgraphics;
 	
-	ExecutorService execService;
+	private ExecutorService execService;
 	
 	private FrmInterpret(XGraphics xg) {
 		setLayout(new BorderLayout());
@@ -87,12 +87,9 @@ public class FrmInterpret extends Frame {
 		});
 		
 	}
-	
-	
-	StepCallbackImpl callback = new StepCallbackImpl();
-	
 
-	
+	private StepCallbackImpl callback = new StepCallbackImpl();
+
 	private void doStart() {
 		Runnable runnable = new Runnable() {
 			public void run() {	
@@ -106,7 +103,7 @@ public class FrmInterpret extends Frame {
 		execService.submit(runnable);
 	}
 	
-	void doStep() {
+	private void doStep() {
 		synchronized(callback) {
 			callback.notify();
 		}
@@ -156,9 +153,8 @@ public class FrmInterpret extends Frame {
 			}
 		}		
 	}
-	
-	
-	public static void open(XGraphics xg) {
+
+	private static void open(XGraphics xg) {
 		FrmInterpret frm = new FrmInterpret(xg);
 		frm.setBounds(400, 400, 500, 500);
 		frm.setVisible(true);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Generator.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Generator.java
@@ -43,7 +43,7 @@ public class Generator {
 		}		
 	}
 
-	static void dump(Method meth) {
+	private static void dump(Method meth) {
 		String template =
 				"@Override\n" +
 				"public %1$s %2$s(%3$s) { \n " +

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/ImageEvent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/ImageEvent.java
@@ -32,7 +32,7 @@ public class ImageEvent extends EventObject {
 	private BufferedImage image;
 	private Operation lastOperation;
 	
-	public ImageEvent(Player source, BufferedImage imageP, Operation lastOperationP) {
+	ImageEvent(Player source, BufferedImage imageP, Operation lastOperationP) {
 		super(source);
 		image = imageP;
 		lastOperation = lastOperationP;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Operation.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Operation.java
@@ -36,9 +36,9 @@ public class Operation {
 	Method method;
 	Object[] arguments;
 	int graphicsIndex;
-	int opIndex;
-	boolean endOperation;
-	StackTraceElement[] stackTrace;
+	private int opIndex;
+	private boolean endOperation;
+	private StackTraceElement[] stackTrace;
 	
 	// constructor for a special purpose of creating END operation
 	private Operation(int index) {
@@ -106,7 +106,7 @@ public class Operation {
 	}
 
 	// helper for toString
-	String getTypeName(Class<?> type) {
+    private String getTypeName(Class<?> type) {
 		if (type.isArray()) {
 			try {
 				Class<?> cl = type;
@@ -131,7 +131,7 @@ public class Operation {
 		return opIndex;
 	}
 
-	public static Operation createEndOperation(int index) {
+	static Operation createEndOperation(int index) {
 		return new Operation(index);
 	}
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/OperationResetEvent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/OperationResetEvent.java
@@ -29,10 +29,10 @@ import java.util.EventObject;
  */
 public class OperationResetEvent extends EventObject {
 
-	Operation[] operations;
-	Dimension imageSize;
+	private Operation[] operations;
+	private Dimension imageSize;
 	
-	public OperationResetEvent(Player source, Operation[] operationsP, Dimension imageSizeP) {
+	OperationResetEvent(Player source, Operation[] operationsP, Dimension imageSizeP) {
 		super(source);
 		operations = operationsP;
 		imageSize = imageSizeP;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Player.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Player.java
@@ -44,20 +44,20 @@ import org.swingexplorer.Options;
  */
 public class Player {
     
-	Operation[] operations;
+	private Operation[] operations;
 	int stepTime = 100;
-	EventListenerList listenerList = new EventListenerList();
+	private EventListenerList listenerList = new EventListenerList();
 	
-	PState state;
-	Timer playTimer;
+	private PState state;
+	private Timer playTimer;
 	
 	
-	BufferedImage workerImage;
-	Graphics g;
-	ArrayList<Graphics> openGraphics = new ArrayList<Graphics>();
-	int currentOperationIndex = -1;
+	private BufferedImage workerImage;
+	private Graphics g;
+	private ArrayList<Graphics> openGraphics = new ArrayList<Graphics>();
+	private int currentOperationIndex = -1;
 	
-	Options options;
+	private Options options;
 	
 	
 	public enum PState {
@@ -170,7 +170,7 @@ public class Player {
 		setCurrentOperationIndex(this.operations.length - 1);
 	}
 	
-	public void setOperations(Operation[] operationsP, Dimension imageSize) {				
+	private void setOperations(Operation[] operationsP, Dimension imageSize) {
 		resetImage(imageSize);
 		operations = operationsP;		
 		setCurrentState(PState.IDLE);
@@ -286,7 +286,7 @@ public class Player {
 		}
 	}
     
-	void log(String text) {
+	private void log(String text) {
 //		System.err.println(text);
 	}
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/StateEvent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/StateEvent.java
@@ -34,7 +34,7 @@ public class StateEvent extends EventObject {
 	private PState newState;
 	private PState oldState;
 	
-	public StateEvent(Player source, PState oldStateP, PState newStateP) {
+	StateEvent(Player source, PState oldStateP, PState newStateP) {
 		super(source);
 		newState = newStateP;
 		oldState = oldStateP;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/XGraphics.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/XGraphics.java
@@ -47,16 +47,16 @@ public class XGraphics extends Graphics2D {
 
 	
 	Graphics2D graphics;
-	Callback callback;
-	ArrayList<Operation> operations;
-	ArrayList<Graphics> openGraphics;
+	private Callback callback;
+	private ArrayList<Operation> operations;
+	private ArrayList<Graphics> openGraphics;
 	
 	
-	public XGraphics(Graphics2D graphics) {
+	XGraphics(Graphics2D graphics) {
 		this(graphics, null);
 	}
 	
-	public XGraphics(Graphics2D graphics, Callback callbackP) {
+	private XGraphics(Graphics2D graphics, Callback callbackP) {
 		this.graphics = graphics;
 		operations = new ArrayList<Operation>();
 		openGraphics = new ArrayList<Graphics>();
@@ -76,7 +76,7 @@ public class XGraphics extends Graphics2D {
 	 * and resets internal operation list to empty.
 	 * Detached operation list contains END operation at the end.
 	 */
-	public ArrayList<Operation> detachOperations() {
+    ArrayList<Operation> detachOperations() {
 		ArrayList<Operation> detachOps = operations;
 		
 		//	add END marker operation to operation list, 
@@ -129,7 +129,7 @@ public class XGraphics extends Graphics2D {
 		out.println("OpCount: " + operations.size());
 	}
 	
-	Object operation(String methodName, Object...args) {
+	private Object operation(String methodName, Object... args) {
 		
 		//	obtain arguments and types
 		Class<?>[] types = new Class[args.length/2];
@@ -177,11 +177,11 @@ public class XGraphics extends Graphics2D {
 		return res;
 	}
 	
-	public int getOperationCount() {
+	int getOperationCount() {
 		return operations.size();
 	}
 	
-	public void interpret(Graphics g, int toStep, Callback callback) {
+	void interpret(Graphics g, int toStep, Callback callback) {
 		
 		
 		ArrayList<Graphics> openGraphics = new ArrayList<Graphics>();
@@ -592,7 +592,7 @@ public class XGraphics extends Graphics2D {
 	// method clones object through relection
 	// in some cases memorized argument values
 	// should be cloned to avoud their modification later
-	Object forceClone(Object toClone) {
+    private Object forceClone(Object toClone) {
 		if(toClone == null) {
 			return null;
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/idesupport/IDESupport.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/idesupport/IDESupport.java
@@ -42,14 +42,14 @@ import org.swingexplorer.SysUtils;
  */
 public class IDESupport extends NotificationBroadcasterSupport implements IDESupportMBean {
 
-    int notificationNumber = 0;
+    private int notificationNumber = 0;
     
     // if bound is false then IDESupport is switched off
     // and IDESupport is not bound to RMI registry at all
-    boolean bound;
+    private boolean bound;
     
     // this flag determines if plugin connected the MBean
-    boolean connected;
+    private boolean connected;
     
     
     private IDESupport() {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
@@ -33,8 +33,8 @@ import org.swingexplorer.Options;
  */
 public abstract class AbstractOnResizePersonalizer<T extends Component> implements Personalizer {
 
-	protected Options options;
-	protected T component;
+	Options options;
+	T component;
 	
 	public void install(Options _options, Component _component) {
 		component = (T)_component;
@@ -54,7 +54,7 @@ public abstract class AbstractOnResizePersonalizer<T extends Component> implemen
 	 * Applies state from positions to component.
 	 * The method is called when component is first resized
 	 */
-	public abstract void applyState();
+	protected abstract void applyState();
 	
 	/**
 	 * {@inheritDoc}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/FramePersonalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/FramePersonalizer.java
@@ -31,8 +31,8 @@ import org.swingexplorer.Options;
  */
 public class FramePersonalizer implements Personalizer {
 	
-	Options options;
-	JFrame frame;
+	private Options options;
+	private JFrame frame;
 	
 	public void install(Options _options, Component _component) {
 		options = _options;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/PersonalizerRegistry.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/PersonalizerRegistry.java
@@ -33,10 +33,10 @@ import org.swingexplorer.Options;
  */
 public class PersonalizerRegistry {
 
-	Container parentContainer;
-	Options options;
+	private Container parentContainer;
+	private Options options;
 	
-	LinkedList<Personalizer> personalizers = new LinkedList<Personalizer>(); 
+	private LinkedList<Personalizer> personalizers = new LinkedList<Personalizer>();
 	
 	public PersonalizerRegistry(Container _parentContainer, Options _options) {
 		parentContainer = _parentContainer;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
@@ -38,7 +38,7 @@ import javax.swing.plaf.metal.MetalComboBoxUI;
 public class CustomComboBoxUI extends MetalComboBoxUI {
 
     
-	EtchedBorder border = new EtchedBorder();
+	private EtchedBorder border = new EtchedBorder();
 	
     @Override
     protected void installDefaults() {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomSplitPaneDivider.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomSplitPaneDivider.java
@@ -33,7 +33,7 @@ import javax.swing.plaf.basic.BasicSplitPaneUI;
  */
 public class CustomSplitPaneDivider extends BasicSplitPaneDivider {
 
-	public CustomSplitPaneDivider(BasicSplitPaneUI ui) {
+	CustomSplitPaneDivider(BasicSplitPaneUI ui) {
 		super(ui);		
 	}
 	

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTabbedPaneUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTabbedPaneUI.java
@@ -31,12 +31,12 @@ import javax.swing.plaf.metal.MetalTabbedPaneUI;
  */
 public class CustomTabbedPaneUI extends MetalTabbedPaneUI {
 
-	boolean tabsOverlapBorder = false;
+	private boolean tabsOverlapBorder = false;
 	private boolean contentOpaque = true;
 	private Color selectedColor = new Color(200, 221, 242);
 	private Color unselectedColor = new Color(0xdadada);
 
-	public CustomTabbedPaneUI() {
+	CustomTabbedPaneUI() {
 	}
 
 	@Override

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTableHeaderUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTableHeaderUI.java
@@ -50,7 +50,7 @@ public class CustomTableHeaderUI extends BasicTableHeaderUI {
 
         Border normalBorder;
 
-        public HeaderCellRenderer() {
+        HeaderCellRenderer() {
             super();
             
             Border bevel = BorderFactory.createEtchedBorder();// .createBevelBorder(BevelBorder.RAISED,Color.white,Color.white,new Color(115, 114, 105),new Color(165, 163, 151));

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/PlafUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/PlafUtils.java
@@ -40,7 +40,7 @@ import javax.swing.JTree;
  */
 public abstract class PlafUtils {
 
-    public static final Font CUSTOM_FONT = new Font("Dialog", Font.PLAIN, 12);
+    static final Font CUSTOM_FONT = new Font("Dialog", Font.PLAIN, 12);
     
     
     public static final void applyCustomLookAndFeel(Container parent) {
@@ -78,5 +78,5 @@ public abstract class PlafUtils {
         }
     }
     
-    static CustomButtonUI sharedButtonUI = new CustomButtonUI();
+    private static CustomButtonUI sharedButtonUI = new CustomButtonUI();
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/properties/MdlProperties.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/properties/MdlProperties.java
@@ -43,9 +43,9 @@ import org.swingexplorer.Log;
  */
 public class MdlProperties extends AbstractTableModel {
 
-	Object bean;	
-	String[][] properties = new String[0][0];
-	String[] colNames = new String[] {"name", "value"};
+	private Object bean;
+	private String[][] properties = new String[0][0];
+	private String[] colNames = new String[] {"name", "value"};
 	
     // properties shown first of all at the beginning
     HashSet<String> firstKeys = new HashSet<String>(Arrays.asList(new String[] {
@@ -55,7 +55,7 @@ public class MdlProperties extends AbstractTableModel {
     
     
 	@SuppressWarnings("rawtypes")
-	public Map describe(Object bean) {
+    private Map describe(Object bean) {
 		if(bean == null) {
 			return new HashMap();
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/properties/PnlPropertySheet.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/properties/PnlPropertySheet.java
@@ -34,9 +34,9 @@ import org.swingexplorer.plaf.CustomTableHeaderUI;
  */
 public class PnlPropertySheet extends JPanel {
 
-	MdlProperties mdlProperties;
-	JTable tblProperties;
-	JScrollPane scpTable;
+	private MdlProperties mdlProperties;
+	private JTable tblProperties;
+	private JScrollPane scpTable;
 	
 	public PnlPropertySheet() {
 		

--- a/swingexplorer-core/src/main/java/org/swingexplorer/util/ListenerSupport.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/util/ListenerSupport.java
@@ -30,9 +30,9 @@ import java.util.ArrayList;
  */
 public class ListenerSupport<L> {
 
-    ArrayList<L> listeners;
-    Class<?> listenerInterface;
-    L proxy;
+    private ArrayList<L> listeners;
+    private Class<?> listenerInterface;
+    private L proxy;
     
     public ListenerSupport(Class<?> _listenerInterface) {
         listenerInterface = _listenerInterface;

--- a/swingexplorer-core/src/main/java/sample/CheckThreadViolationRepaintManager.java
+++ b/swingexplorer-core/src/main/java/sample/CheckThreadViolationRepaintManager.java
@@ -49,11 +49,11 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
     private boolean completeCheck = true;
     private WeakReference<JComponent> lastComponent;
 
-    public CheckThreadViolationRepaintManager(boolean completeCheck) {
+    private CheckThreadViolationRepaintManager(boolean completeCheck) {
         this.completeCheck = completeCheck;
     }
 
-    public CheckThreadViolationRepaintManager() {
+    private CheckThreadViolationRepaintManager() {
         this(true);
     }
 

--- a/swingexplorer-core/src/main/java/sample/FrmPerson.java
+++ b/swingexplorer-core/src/main/java/sample/FrmPerson.java
@@ -32,7 +32,7 @@ import javax.swing.JOptionPane;
 public class FrmPerson extends javax.swing.JFrame {
     
     /** Creates new form FrmPerson */
-    public FrmPerson() {
+    private FrmPerson() {
         initComponents();
     }
     


### PR DESCRIPTION
I don't know if you necessarily want to do this, but:

A lot of the access modifiers on fields and methods in the code base could be strengthened. For example, "public" or package-default replaced with "protected" or "private". This will have no effect on behavior, but it could help with code quality: with this in place, methods and especially fields that are widely accessed will now stand out. And it could make it easier for us to use static analysis tools to improve code quality.

Coming from a software engineering background, I think this would be a good idea. It would let us zero in on parts of the design that _are_ unnecessarily open, and maybe tighten them up.

This PR tightens up the access modifiers on many fields and methods. In particular, it makes many package-default fields now private.