### PR TITLE
Fix a couple implicit NullPointerExceptions

### DIFF
--- a/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleButton.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/RichToggleButton.java
@@ -63,8 +63,9 @@ public class RichToggleButton extends JToggleButton {
 			if(curAction != null) {
 				curAction.removePropertyChangeListener(selectionStateListener);
 			}
-		}
-		newAction.addPropertyChangeListener(selectionStateListener);		
+		} else {
+            newAction.addPropertyChangeListener(selectionStateListener);
+        }
 		super.setAction(newAction);
 	}
 	


### PR DESCRIPTION
This PR fixes a couple spots where NullPointerExceptions ("NPEs") may be implicitly raised by dereferencing variables that may be null.

In the case of BeanSaver, it does more checks to see whether `findGetter` or `findSetter` failed to find the appropriate method, and if so, raises a `RuntimeException` with a more informative message instead of raising an NPE.

In the case of RichToggleButton, it just fixes some if/else logic around a null test to avoid invoking a method on a null reference.