### PR TITLE
Add support for Maven Central signing and deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,47 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <keyname>Swing Explorer Admin</keyname>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR modifies the POM to add a GPG signing step and OSSRH deployment step. This is required for publishing to Maven Central.

I have done a test snapshot deployment of swingexplorer 1.7.0-SNAPSHOT using this modified POM. You can see the published results at https://oss.sonatype.org/content/repositories/snapshots/org/swingexplorer/.

<strike>This test publishing is signed with my personal GPG key. I'm looking in to modifying the configuration to use a Swing Explorer specific GPG key that we can share.</strike> I have updated the PR to use the 'Swing Explorer Admin' GPG key.

I'm putting in a Javadoc publishing plugin configuration because I think we should include Javadoc JARs in the published artifacts for completeness, even if we are not using them ourselves. Most Maven Central published projects include javadoc JARs, and they show up as "!" warning statuses in many Java IDEs if they are missing.

In fact, based on https://central.sonatype.org/pages/requirements.html#supply-javadoc-and-sources, it looks like Javadoc JARs will be required by OSSRH for publishing non-SNAPSHOT releases.

Depends on #32 to get the Javadoc building without error.
