### PR TITLE
Replace private sun.swing.DefaultLookup with UIManager calls

### DIFF
--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
@@ -31,8 +31,6 @@ import javax.swing.UIManager;
 import javax.swing.border.EtchedBorder;
 import javax.swing.plaf.metal.MetalComboBoxUI;
 
-import sun.swing.DefaultLookup;
-
 /**
  *
  * @author  Maxim Zakharenkov
@@ -94,10 +92,8 @@ public class CustomComboBoxUI extends MetalComboBoxUI {
                 c.setBackground(comboBox.getBackground());
             }
             else {
-                c.setForeground(DefaultLookup.getColor(
-                         comboBox, this, "ComboBox.disabledForeground", null));
-                c.setBackground(DefaultLookup.getColor(
-                         comboBox, this, "ComboBox.disabledBackground", null));
+                c.setForeground(UIManager.getColor("ComboBox.disabledForeground"));
+                c.setBackground(UIManager.getColor("ComboBox.disabledBackground"));
             }
         }
 


### PR DESCRIPTION
The `sun.swing.DefaultLookup` class is not public API, so it generates compiler warnings when called, and prevents Javadoc from being generated correctly.

This PR replaces its use with `UIManager` calls, which are public API.