### PR TITLE
Tweak about box

### DIFF
--- a/make_dist
+++ b/make_dist
@@ -14,7 +14,7 @@ mkdir -p "$dist"/lib
 
 
 # Assemble files
-cp $M2_REPO/org/jdesktop/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
+cp $M2_REPO/org/swinglabs/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
 cp $M2_REPO/javassist/javassist/3.12.1.GA/javassist-3.12.1.GA.jar "$dist"/lib
 cp swingexplorer-core/target/swingexplorer-core-$VERSION.jar "$dist"
 cp swingexplorer-agent/target/swingexplorer-agent-$VERSION.jar "$dist"

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -44,7 +44,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {
 
-			Component component = PNLComponentTree.getComponent(curPath);
+			Component component = PnlComponentTree.getComponent(curPath);
 
 			if (e.isAddedPath(curPath)) {
 				model.addSelection(component);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlAbout.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlAbout.java
@@ -107,6 +107,7 @@ public class PnlAbout extends javax.swing.JPanel {
         setLayout(new BorderLayout());
         add(pnlGrid, BorderLayout.NORTH);
         add(lblCopyright, BorderLayout.SOUTH);
+        setBorder(BorderFactory.createEmptyBorder(15, 15, 15, 15));
     }
     
     static void openModal(Frame owner) {
@@ -116,6 +117,7 @@ public class PnlAbout extends javax.swing.JPanel {
 		
 		PnlAbout pnlAbout = new PnlAbout();
 		dlgAbout.add(pnlAbout);
+		dlgAbout.setResizable(false);
 		dlgAbout.pack();
 		GuiUtils.center(owner, dlgAbout);
 		dlgAbout.setVisible(true);


### PR DESCRIPTION
Fix up the About box some more, making it non-resizable, and adding an empty border to make it more readable.

Also picks up a couple fixes to the build.

Addresses #9. 