### PR TITLE
Expand sample program and move it to com.example package

### DIFF
--- a/make_dist
+++ b/make_dist
@@ -14,7 +14,7 @@ mkdir -p "$dist"/lib
 
 
 # Assemble files
-cp $M2_REPO/org/jdesktop/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
+cp $M2_REPO/org/swinglabs/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
 cp $M2_REPO/javassist/javassist/3.12.1.GA/javassist-3.12.1.GA.jar "$dist"/lib
 cp swingexplorer-core/target/swingexplorer-core-$VERSION.jar "$dist"
 cp swingexplorer-agent/target/swingexplorer-agent-$VERSION.jar "$dist"

--- a/swingexplorer-core/src/main/java/com/example/CheckThreadViolationRepaintManager.java
+++ b/swingexplorer-core/src/main/java/com/example/CheckThreadViolationRepaintManager.java
@@ -17,7 +17,7 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *   
  */
-package sample;
+package com.example;
 
 
 import java.lang.ref.WeakReference;

--- a/swingexplorer-core/src/main/java/com/example/FrmPerson.form
+++ b/swingexplorer-core/src/main/java/com/example/FrmPerson.form
@@ -239,7 +239,7 @@
         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
           <Font name="Tahoma" size="12" style="1"/>
         </Property>
-        <Property name="text" type="java.lang.String" value="This is sample Swing application to demonstrate Swing Explorer"/>
+        <Property name="text" type="java.lang.String" value="This is a sample Swing application to demonstrate Swing Explorer"/>
       </Properties>
     </Component>
     <Component class="javax.swing.JButton" name="btnModalDialog">

--- a/swingexplorer-core/src/main/java/com/example/FrmPerson.java
+++ b/swingexplorer-core/src/main/java/com/example/FrmPerson.java
@@ -18,7 +18,7 @@
  * 
  *  $Header: /zpool01/javanet/scm/svn/tmp/cvs2svn/swingexplorer/src/sample/FRMPerson.java,v 1.6 2008-04-09 10:39:57 maxz1 Exp $
  */
-package sample;
+package com.example;
 
 import javax.swing.JDialog;
 import javax.swing.JEditorPane;
@@ -32,7 +32,7 @@ import javax.swing.JOptionPane;
 public class FrmPerson extends javax.swing.JFrame {
     
     /** Creates new form FrmPerson */
-    private FrmPerson() {
+    FrmPerson() {
         initComponents();
     }
     
@@ -125,7 +125,7 @@ public class FrmPerson extends javax.swing.JFrame {
         cmbCountry.setModel(new javax.swing.DefaultComboBoxModel<String>(new String[] { "England", "Belgium", "France", "Spain", "Italy", "Germany" }));
 
         lblDescription.setFont(new java.awt.Font("Tahoma", 1, 12));
-        lblDescription.setText("This is sample Swing application to demonstrate Swing Explorer");
+        lblDescription.setText("This is a sample Swing application to demonstrate Swing Explorer");
 
         btnModalDialog.setText("Modal Dialog");
         btnModalDialog.addActionListener(new java.awt.event.ActionListener() {
@@ -346,18 +346,6 @@ public class FrmPerson extends javax.swing.JFrame {
         int zero = 0;
         int j = i/zero;
     }//GEN-LAST:event_btnExceptionInEDTActionPerformed
-    
-    /**
-     * @param args the command line arguments
-     */
-    public static void main(String args[]) {
-        java.awt.EventQueue.invokeLater(new Runnable() {
-            public void run() {
-                FrmPerson frmPerson = new FrmPerson();
-                frmPerson.setVisible(true);
-            }
-        });
-    }
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnCheckEDT;

--- a/swingexplorer-core/src/main/java/com/example/PersonEditor.java
+++ b/swingexplorer-core/src/main/java/com/example/PersonEditor.java
@@ -1,0 +1,18 @@
+package com.example;
+
+public class PersonEditor {
+
+    /**
+     * Launches the example PersonEditor application.
+     * @param args the command line arguments (ignored)
+     */
+    public static void main(String args[]) {
+        java.awt.EventQueue.invokeLater(new Runnable() {
+            public void run() {
+                FrmPerson frmPerson = new FrmPerson();
+                frmPerson.setVisible(true);
+            }
+        });
+    }
+
+}

--- a/swingexplorer-core/src/main/java/com/example/PersonEditorWithSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/com/example/PersonEditorWithSwingExplorer.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class PersonEditorWithSwingExplorer {
+    public static void main(String args[]) {
+        org.swingexplorer.Launcher.main(new String[] {"com.example.PersonEditor"});
+    }
+}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -44,7 +44,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {
 
-			Component component = PNLComponentTree.getComponent(curPath);
+			Component component = PnlComponentTree.getComponent(curPath);
 
 			if (e.isAddedPath(curPath)) {
 				model.addSelection(component);


### PR DESCRIPTION
The com.example package is based on the well-known domain example.com,
which is defined specifically for use in examples, and won't clash with any
other packages.

Breaks the sample main method out to a PersonEditor class, so we're not referencing
just the Form class.

Adds a PersonEditorWithSwingExplorer example launcher, to make it convenient to run
the sample under Swing Explorer from within IDEs like IntelliJ, without having to go through an external build and run step.