### PR TITLE
PnlEDTMonitor: replace implicit NPE with a RuntimeException

### DIFF
--- a/make_dist
+++ b/make_dist
@@ -14,7 +14,7 @@ mkdir -p "$dist"/lib
 
 
 # Assemble files
-cp $M2_REPO/org/jdesktop/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
+cp $M2_REPO/org/swinglabs/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
 cp $M2_REPO/javassist/javassist/3.12.1.GA/javassist-3.12.1.GA.jar "$dist"/lib
 cp swingexplorer-core/target/swingexplorer-core-$VERSION.jar "$dist"
 cp swingexplorer-agent/target/swingexplorer-agent-$VERSION.jar "$dist"

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -44,7 +44,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {
 
-			Component component = PNLComponentTree.getComponent(curPath);
+			Component component = PnlComponentTree.getComponent(curPath);
 
 			if (e.isAddedPath(curPath)) {
 				model.addSelection(component);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/PnlEDTMonitor.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/PnlEDTMonitor.java
@@ -29,6 +29,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.IOException;
 import java.io.StringReader;
 import java.util.HashSet;
 
@@ -40,6 +41,7 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLDocument.Iterator;
@@ -137,8 +139,10 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
         try {
 			new HTMLEditorKit().read(reader, doc, 0);
 			text = doc.getText(0, doc.getLength());
-		} catch (Exception e1) {
-		} 
+		} catch (IOException | BadLocationException ex) {
+            throw new RuntimeException("Unable to get text from component at location 0: "
+                + ex.getMessage());
+		}
 		
 		
 		int idx1 = text.indexOf("(");


### PR DESCRIPTION
Fixes #27.

In PnlEDTMonitor, there's a possible implicitly-caused NullPointerException. See #27 for details.

This adds a check for the failure case and raises a RuntimeException with an error message with some details. That won't be useful to the end user, but it'll at least help with debugging.