### PR TITLE
Fix pink square checkboxes on macOS

### DIFF
--- a/make_dist
+++ b/make_dist
@@ -14,7 +14,7 @@ mkdir -p "$dist"/lib
 
 
 # Assemble files
-cp $M2_REPO/org/jdesktop/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
+cp $M2_REPO/org/swinglabs/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
 cp $M2_REPO/javassist/javassist/3.12.1.GA/javassist-3.12.1.GA.jar "$dist"/lib
 cp swingexplorer-core/target/swingexplorer-core-$VERSION.jar "$dist"
 cp swingexplorer-agent/target/swingexplorer-agent-$VERSION.jar "$dist"

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -44,7 +44,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {
 
-			Component component = PNLComponentTree.getComponent(curPath);
+			Component component = PnlComponentTree.getComponent(curPath);
 
 			if (e.isAddedPath(curPath)) {
 				model.addSelection(component);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/Launcher.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/Launcher.java
@@ -216,8 +216,7 @@ public class Launcher implements Runnable {
         String userProgramClassSimpleName = (ixLastDot >= 0) ? userProgramClassName.substring(ixLastDot + 1)
             : userProgramClassName;
         String appDisplayName = "Swing Explorer - " + userProgramClassSimpleName;
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.contains("mac")) {
+        if (SysUtils.isMacOS()) {
             System.setProperty("apple.awt.application.name", appDisplayName);
         }
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/SysUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/SysUtils.java
@@ -183,5 +183,14 @@ public abstract class SysUtils {
 	static boolean isLogToConsole() {
 		return Boolean.getBoolean(KEY_LOG_CONSOLE);
 	}
+
+    /**
+     * Whether this process is running on macOS.
+     * @return true if running on macOS
+     */
+    public static boolean isMacOS() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        return osName.contains("mac");
+    }
 }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/PlafUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/PlafUtils.java
@@ -19,6 +19,8 @@
  */
 package org.swingexplorer.plaf;
 
+import org.swingexplorer.SysUtils;
+
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Font;
@@ -68,7 +70,11 @@ public abstract class PlafUtils {
         } else if(component instanceof JLabel) {
             ((JLabel)component).setUI(new CustomLabelUI());
         } else if(component instanceof JCheckBox) {
-            ((JCheckBox)component).setUI(new CustomCheckboxUI());
+            // Custom CheckBox PLAF is broken on macOS
+            // See https://github.com/swingexplorer/swingexplorer/issues/43
+            if (!SysUtils.isMacOS()) {
+                ((JCheckBox) component).setUI(new CustomCheckboxUI());
+            }
         } else if(component instanceof JSpinner) {
             ((JSpinner)component).setUI(new CustomSpinnerUI());
         } else if(component instanceof JComboBox) {


### PR DESCRIPTION
Fixes #43.

This is a quick fix for the "checkboxes appear as pink squares" issue on macOS. It checks what OS we are running on, and skips the custom UI for JCheckBoxes on macOS only.

With this fix, checkboxes appear as normal on macOS for me.