### PR TITLE
Little extra border on Swing Explorer UI

### DIFF
--- a/make_dist
+++ b/make_dist
@@ -14,7 +14,7 @@ mkdir -p "$dist"/lib
 
 
 # Assemble files
-cp $M2_REPO/org/jdesktop/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
+cp $M2_REPO/org/swinglabs/swing-layout/1.0.3/swing-layout-1.0.3.jar "$dist"/lib
 cp $M2_REPO/javassist/javassist/3.12.1.GA/javassist-3.12.1.GA.jar "$dist"/lib
 cp swingexplorer-core/target/swingexplorer-core-$VERSION.jar "$dist"
 cp swingexplorer-agent/target/swingexplorer-agent-$VERSION.jar "$dist"

--- a/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/ActTreeSelectionChanged.java
@@ -44,7 +44,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {
 
-			Component component = PNLComponentTree.getComponent(curPath);
+			Component component = PnlComponentTree.getComponent(curPath);
 
 			if (e.isAddedPath(curPath)) {
 				model.addSelection(component);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/PnlSwingExplorer.java
@@ -29,6 +29,7 @@ import java.beans.PropertyChangeListener;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
+import javax.swing.BorderFactory;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
@@ -55,6 +56,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
         sppRight.setName("sppRight");
         tbpBottom.setName("tbpBottom");
         pnlProperties.setName("pnlProperties");
+        setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
         
         // animated icon for event monitor
         icoEventMonitoring = new AnimatedIcon(tbpBottom);


### PR DESCRIPTION
This is a minor cosmetic enhancement. It adds a small border around the whole Swing Explorer UI inside its frame, which I think makes it look a little tidier. Right now, there is no border, so on the right hand side, the text area of the bottom tabbed pane is flush right with the window border. That's a little disorienting, especially under window managers like macOS that do not put *any* border around top-level windows/frames.