### PR TITLE
Add dist to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+dist
+
 **/target
 
 # JetBrains IntelliJ


### PR DESCRIPTION
This makes .gitignore work better for users without global gitignores that ignore `dist/`.