### PR TITLE
Fix Windows launcher script

### DIFF
--- a/make_dist
+++ b/make_dist
@@ -19,7 +19,7 @@ cp $M2_REPO/javassist/javassist/3.12.1.GA/javassist-3.12.1.GA.jar "$dist"/lib
 cp swingexplorer-core/target/swingexplorer-core-$VERSION.jar "$dist"
 cp swingexplorer-agent/target/swingexplorer-agent-$VERSION.jar "$dist"
 cp -pR src/dist-files/* "$dist"
-cp -pR README.md docs manual "$dist"
+cp -pR README.md docs manual VERSION "$dist"
 
 cd dist
 

--- a/src/dist-files/bin/swexpl.bat
+++ b/src/dist-files/bin/swexpl.bat
@@ -37,6 +37,7 @@
 set user_classpath=
 set use_agent=y
 set user_mainclass=
+set swexpl_version=@SWINGEXPLORER_VERSION@
 
 set bin_dir=%~dp0
 set bin_dir=%bin_dir:~0,-1%
@@ -45,7 +46,6 @@ pushd %bin_dir%
 cd /d ..
 set dist_dir=%cd%
 set lib_dir=%dist_dir%\lib
-set /p swexpl_version=<VERSION
 popd
 
 :Loop
@@ -86,7 +86,7 @@ if "%user_classpath"=="" (
 )
 
 if "%use_agent%"=="y" (
-    %java% -javaagent:%agent_jar_file% -Xbootclasspath/a:%agent_classpath% -cp %eff_classpath% org.swingexplorer.launcher %user_mainclass% %1 %2 %3 %4 %5 %6 %7 %8 %9
+    %java% -javaagent:%agent_jar_file% -Xbootclasspath/a:%agent_classpath% -cp %eff_classpath% org.swingexplorer.Launcher %user_mainclass% %1 %2 %3 %4 %5 %6 %7 %8 %9
 ) else (
     %java% -cp "%eff_classpath%;%agent_classpath%" org.swingexplorer.Launcher %user_mainclass% %1 %2 %3 %4 %5 %6 %7 %8 %9
 )


### PR DESCRIPTION
Fixes the launcher script on Windows.

There was a typo in the class name in the code path for launching the agent. Fixed.

Reading the version from a file wasn't working, because it wasn't getting the path right. Switched to the mechanism where `make_dist` munges the script to have the right version from the POM.

Launcher script works on Windows again. I tested it locally using the example PersonEditor program that ships with Swing Explorer.