### PR TITLE
Add @Override annotations

### DIFF
--- a/swingexplorer-agent/src/main/java/org/swingexplorer/instrument/Agent.java
+++ b/swingexplorer-agent/src/main/java/org/swingexplorer/instrument/Agent.java
@@ -190,7 +190,8 @@ public class Agent {
     static class Transformer implements ClassFileTransformer {
         
         boolean first = true;
-     
+
+        @Override
         public byte[] transform(ClassLoader loader, 
                         String className, 
                         Class<?> redefiningClass, 

--- a/swingexplorer-agent/src/main/java/org/swingexplorer/instrument/Problem.java
+++ b/swingexplorer-agent/src/main/java/org/swingexplorer/instrument/Problem.java
@@ -49,7 +49,8 @@ public class Problem {
         }
         return buf.toString();
     }
-    
+
+    @Override
     public String toString() {
         return problemDescription;
     }

--- a/swingexplorer-core/src/main/java/com/example/CheckThreadViolationRepaintManager.java
+++ b/swingexplorer-core/src/main/java/com/example/CheckThreadViolationRepaintManager.java
@@ -60,11 +60,13 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
         this.completeCheck = completeCheck;
     }
 
+    @Override
     public synchronized void addInvalidComponent(JComponent component) {
         checkThreadViolations(component);
         super.addInvalidComponent(component);
     }
 
+    @Override
     public void addDirtyRegion(JComponent component, int x, int y, int w, int h) {
         checkThreadViolations(component);
         super.addDirtyRegion(component, x, y, w, h);
@@ -116,7 +118,7 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
         RepaintManager.setCurrentManager(new CheckThreadViolationRepaintManager());
         //Valid code  
         SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
+            @Override public void run() {
                 test();
             }
         });
@@ -126,7 +128,7 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
         //Invalide code (stack trace expected) 
 //        test();
         SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
+            @Override public void run() {
                 imageUpdateTest();
             }
         });
@@ -158,7 +160,7 @@ public class CheckThreadViolationRepaintManager extends RepaintManager {
     static void repaintTest() {
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
-                public void run() {
+                @Override public void run() {
                     test = new JButton();
                     test.setSize(100, 100);
                 }

--- a/swingexplorer-core/src/main/java/com/example/FrmPerson.java
+++ b/swingexplorer-core/src/main/java/com/example/FrmPerson.java
@@ -68,6 +68,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         btnCheckEDT.setText("jButton1");
         btnCheckEDT.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnCheckEDTActionPerformed(evt);
             }
@@ -82,6 +83,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         pnlGender.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Gender"));
         pnlGender.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 pnlGenderMouseClicked(evt);
             }
@@ -129,6 +131,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         btnModalDialog.setText("Modal Dialog");
         btnModalDialog.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnModalDialogActionPerformed(evt);
             }
@@ -136,6 +139,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         btnOwnerlessModalDialog.setText("Ownerless Modal Dialog");
         btnOwnerlessModalDialog.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnOwnerlessModalDialogActionPerformed(evt);
             }
@@ -143,6 +147,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         btnModelessDialog.setText("Modeless Dialog");
         btnModelessDialog.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnModelessDialogActionPerformed(evt);
             }
@@ -150,6 +155,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         btnOwnerlessModelessDialog.setText("Ownerless Modeless Dialog");
         btnOwnerlessModelessDialog.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnOwnerlessModelessDialogActionPerformed(evt);
             }
@@ -158,6 +164,7 @@ public class FrmPerson extends javax.swing.JFrame {
         btnThreadViolation.setText("Thread Violation");
         btnThreadViolation.setToolTipText("<html>\nPress this button to simulate<br>\nthread violation.<br> \nCalls method of swing component<br> \nfrom non AWT Dispatch Thread.\n</html>\n");
         btnThreadViolation.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnThreadViolationActionPerformed(evt);
             }
@@ -166,6 +173,7 @@ public class FrmPerson extends javax.swing.JFrame {
         btnEdtHang.setText("EDT Hang");
         btnEdtHang.setToolTipText("<html>\nSimulate long operation in<br>\nAWT dispatch thread causing<br>\nhanging for 2 seconds\n</html>");
         btnEdtHang.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnEdtHangActionPerformed(evt);
             }
@@ -174,6 +182,7 @@ public class FrmPerson extends javax.swing.JFrame {
         btnThreadViolation2.setText("Thread Violation 2");
         btnThreadViolation2.setToolTipText("<html>Calls \"repaint()\" method in a separate thread.<br>\nThe method is considered as thread safe and should<br>\nnot be caught by violation monitor\n</html>");
         btnThreadViolation2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnThreadViolation2ActionPerformed(evt);
             }
@@ -182,6 +191,7 @@ public class FrmPerson extends javax.swing.JFrame {
         btnThreadViolation3.setText("Thread Violation 3");
         btnThreadViolation3.setToolTipText("<html>imageUpdate method is called <br>\ninside Swing in a separate thread and should<br>\nnot be caught by violation monitor\n</html>");
         btnThreadViolation3.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnThreadViolation3ActionPerformed(evt);
             }
@@ -189,6 +199,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
         btnExceptionInEDT.setText("Exception in EDT");
         btnExceptionInEDT.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnExceptionInEDTActionPerformed(evt);
             }
@@ -306,6 +317,7 @@ public class FrmPerson extends javax.swing.JFrame {
 
     private void btnThreadViolationActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnThreadViolationActionPerformed
         new Thread() {
+            @Override
             public void run() {
                 rbnFemale.setToolTipText("Sample");
 //                rbnFemale.scrollRectToVisible(null);
@@ -323,6 +335,7 @@ public class FrmPerson extends javax.swing.JFrame {
     
     private void btnThreadViolation2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnThreadViolation2ActionPerformed
         new Thread() {
+            @Override
             public void run() {
                 rbnFemale.repaint();
             }

--- a/swingexplorer-core/src/main/java/com/example/PersonEditor.java
+++ b/swingexplorer-core/src/main/java/com/example/PersonEditor.java
@@ -8,6 +8,7 @@ public class PersonEditor {
      */
     public static void main(String args[]) {
         java.awt.EventQueue.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 FrmPerson frmPerson = new FrmPerson();
                 frmPerson.setVisible(true);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/ActOpenSourceCode.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/ActOpenSourceCode.java
@@ -36,7 +36,8 @@ public class ActOpenSourceCode implements HyperlinkListener {
 	ActOpenSourceCode(PnlAdditionTrace _owner) {
 		owner = _owner;
 	}
-	
+
+	@Override
 	public void hyperlinkUpdate(HyperlinkEvent e) {
 		if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
 			

--- a/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/NoWrapEditorKit.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/NoWrapEditorKit.java
@@ -37,12 +37,14 @@ import javax.swing.text.html.HTMLEditorKit.HTMLFactory;
 public class NoWrapEditorKit extends HTMLEditorKit {
 
     private ViewFactory defaultFactory=new WrapColumnFactory();
+    @Override
     public ViewFactory getViewFactory() {
         return defaultFactory;
     }
 }
 
 class WrapColumnFactory extends HTMLFactory {
+    @Override
 	public View create(Element elem) {
 	    String kind = elem.getName();
 	    if (kind.equals("p")) {
@@ -57,10 +59,12 @@ class NoWrapParagraphView extends ParagraphView {
         super(elem);
     }
 
+    @Override
     public void layout(int width, int height) {
         super.layout(Short.MAX_VALUE, height);
     }
 
+    @Override
     public float getMinimumSpan(int axis) {
         return super.getPreferredSpan(axis);
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/PnlAdditionTrace.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/additiontrace/PnlAdditionTrace.java
@@ -127,6 +127,7 @@ public class PnlAdditionTrace extends javax.swing.JPanel {
 	
 	
 	class ModelListener implements PropertyChangeListener {
+	    @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			if("selectedComponents".equals(evt.getPropertyName())) {
 				Component[] selected = model.getSelectedComponents();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActClearEvents.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActClearEvents.java
@@ -36,7 +36,8 @@ class ActClearEvents extends RichAction {
 		setName("Clear");
 		setTooltip("Clear events");
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
         owner.clearEvents();
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventFilterChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventFilterChanged.java
@@ -35,7 +35,8 @@ public class ActEventFilterChanged implements ItemListener {
 	public ActEventFilterChanged(PnlEventFilter _owner) {
 		owner = _owner;
 	}
-	
+
+	@Override
 	public void itemStateChanged(ItemEvent e) {
 		Filter filter = owner.commit();
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventSelected.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActEventSelected.java
@@ -33,7 +33,8 @@ public class ActEventSelected implements ListSelectionListener {
 	ActEventSelected(PnlAwtEvents _owner) {
 		owner = _owner;
 	}
-	
+
+	@Override
 	public void valueChanged(ListSelectionEvent e) {
 		owner.pnlEventDetails.setEvent(owner.getSelectedEvent());
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActShowFilter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActShowFilter.java
@@ -56,7 +56,8 @@ public class ActShowFilter extends RichAction {
 
         
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
         if(dlg == null) {
             //  create undecorated dialog
@@ -83,14 +84,14 @@ public class ActShowFilter extends RichAction {
             dlg.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"/**/), "esc_action"/**/
             );
             dlg.getRootPane().getActionMap().put("esc_action"/**/, new AbstractAction() {
-                public void actionPerformed(ActionEvent e) {
+                @Override public void actionPerformed(ActionEvent e) {
                     dlg.setVisible(false);
                 }
             });
             pnlFilter.setFilter(owner.getEventModel().getFilter());
             
             pnlFilter.addFilterChangeListener(new FilterChangeListener() {
-                public void filterChanged(Filter newFilter) {
+                @Override public void filterChanged(Filter newFilter) {
                     owner.getEventModel().setFilter(newFilter);
                 }
             });

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActShowHideEventDetails.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActShowHideEventDetails.java
@@ -31,6 +31,7 @@ import org.swingexplorer.internal.RichAction;
  */
 public class ActShowHideEventDetails extends RichAction {
 
+    @Override
 	public void actionPerformed(ActionEvent e) {
 		// TODO Auto-generated method stub
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStartEventMonitoring.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStartEventMonitoring.java
@@ -38,7 +38,8 @@ public class ActStartEventMonitoring extends RichAction {
 		setIcon("play.png");
 		model = modelP;
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		model.setMonitoring(true);
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStopEventMonitoring.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/ActStopEventMonitoring.java
@@ -38,7 +38,8 @@ public class ActStopEventMonitoring extends RichAction {
 		setIcon("stop.png");
 		model = modelP;
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		model.setMonitoring(false);
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/LocalAWTEventModel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/LocalAWTEventModel.java
@@ -51,7 +51,8 @@ public class LocalAWTEventModel implements AWTEventModel {
 		owner = _owner;
 		filter = new Filter();
 	}
-	
+
+	@Override
 	public void addEventListener(AWTEventListener listener) {
 		if(listener == null) {
 			throw new NullPointerException("Listener can not be null");
@@ -59,10 +60,12 @@ public class LocalAWTEventModel implements AWTEventModel {
 		listeners.add(listener);
 	}
 
+	@Override
 	public void removeEventListener(AWTEventListener listener) {
 		listeners.remove(listener);
 	}
 
+	@Override
 	public void setMonitoring(boolean _monitoring) {
 		if(_monitoring == monitoring) {
 			return;
@@ -76,27 +79,29 @@ public class LocalAWTEventModel implements AWTEventModel {
 		monitoring = _monitoring;
 		firePropertyChanged("monitoring", !monitoring, monitoring);
 	}
-	
+
+	@Override
 	public void addPropertyChangeListener(PropertyChangeListener listener) {
         if (changeSupport == null) {
         	changeSupport = new PropertyChangeSupport(this);
         }
         changeSupport.addPropertyChangeListener(listener);
     }
-	
+
+    @Override
 	public void removePropertyChangeListener(PropertyChangeListener listener) {
         if (changeSupport != null) {
         	changeSupport.removePropertyChangeListener(listener);
         }
     }
-	
+
 	private void firePropertyChanged(String propertyName, Object oldValue, Object newValue) {
 		if(changeSupport != null) {
 			changeSupport.firePropertyChange(propertyName, oldValue, newValue);
 		}
 	}
 	
-	
+	@Override
 	public boolean isMonitoring() {
 		return monitoring;
 	}
@@ -127,6 +132,7 @@ public class LocalAWTEventModel implements AWTEventModel {
 	
 	class Dispatcher implements AWTEventListener {
 
+	    @Override
 		public void eventDispatched(AWTEvent event) {
 			if(!isMatchFilter(event)) {
 				return;
@@ -142,12 +148,14 @@ public class LocalAWTEventModel implements AWTEventModel {
 		}
 	}
 
+	@Override
 	public void setFilter(Filter _filter) {
 		Filter old = filter;
 		filter = _filter;	
 		changeSupport.firePropertyChange("filter", old, filter);
 	}
-	
+
+	@Override
 	public Filter getFilter() {
 		return filter;
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/MdlEvents.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/MdlEvents.java
@@ -129,15 +129,18 @@ public class MdlEvents extends AbstractTableModel {
 	public String getColumnName(int column) {
 		return columns[column].getName();
 	}
-	
+
+	@Override
 	public int getColumnCount() {
 		return columns.length;
 	}
 
+	@Override
 	public int getRowCount() {
 		return events.size();
 	}
 
+	@Override
 	public Object getValueAt(int rowIndex, int columnIndex) {
 		return columns[columnIndex].getValue(rowIndex);
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/PnlAwtEvents.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/PnlAwtEvents.java
@@ -129,12 +129,14 @@ public class PnlAwtEvents extends javax.swing.JPanel {
     }
     
     class ModelListener implements AWTEventListener {
+        @Override
 		public void eventDispatched(AWTEvent event) {
 			addEvent(event);			
 		}    	
     }
 
     public class ModelPropertyChangeListener implements PropertyChangeListener {
+        @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			if("monitoring".equals(evt.getPropertyName())) {
 				if((Boolean)evt.getNewValue()) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/filter/PnlEventFilter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/awt_events/filter/PnlEventFilter.java
@@ -44,6 +44,7 @@ public class PnlEventFilter extends javax.swing.JPanel {
     void initActions() {
     	actEventFilterChanged = new ActEventFilterChanged(this);
     	ItemListener itemListenerProxy = new ItemListener() {
+    	    @Override
 			public void itemStateChanged(ItemEvent e) {
 				if(!itemEventsDisabled) {
 					commit();
@@ -167,7 +168,7 @@ public class PnlEventFilter extends javax.swing.JPanel {
         btnSelectAll.setText("Select all");
         btnSelectAll.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.RAISED));
         btnSelectAll.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            @Override public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnSelectAllActionPerformed(evt);
             }
         });
@@ -175,7 +176,7 @@ public class PnlEventFilter extends javax.swing.JPanel {
         btnClearAll.setText("Deselect all");
         btnClearAll.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.RAISED));
         btnClearAll.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            @Override public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnClearAllActionPerformed(evt);
             }
         });

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/BooleanConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/BooleanConverter.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
  */
 public class BooleanConverter implements Converter<Boolean> {
 
+    @Override
 	public Boolean fromString(String strValue) throws ParseException {
 		if(strValue == null) {
 			return null;
@@ -40,6 +41,7 @@ public class BooleanConverter implements Converter<Boolean> {
 		throw new ParseException("Can not convert \"" + strValue + "\" to boolean", 0);
 	}
 
+	@Override
 	public String toString(Boolean value) {
 		if(value == null) {
 			return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/ColorConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/ColorConverter.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
  */
 public class ColorConverter implements Converter<Color> {
 
+    @Override
 	public Color fromString(String strValue) throws ParseException {
 		if(strValue == null) {
 			return null;
@@ -59,6 +60,7 @@ public class ColorConverter implements Converter<Color> {
 		}
 	}
 
+	@Override
 	public String toString(Color value) {
 		if(value == null) {
 			return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntArrayConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntArrayConverter.java
@@ -28,6 +28,7 @@ import java.util.StringTokenizer;
  */
 public class IntArrayConverter implements Converter<int[]>{
 
+    @Override
 	public int[] fromString(String strValue) throws ParseException {
 
 		StringTokenizer tokens = new StringTokenizer(strValue, ",");
@@ -49,6 +50,7 @@ public class IntArrayConverter implements Converter<int[]>{
 		}
 	}
 
+	@Override
 	public String toString(int[] value) {
 		if(value.length == 0) {
 			return "";

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntegerConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/IntegerConverter.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
  */
 public class IntegerConverter implements Converter<Integer> {
 
+    @Override
 	public Integer fromString(String strValue) throws ParseException {
 		if(strValue == null) {
 			return null;
@@ -38,6 +39,7 @@ public class IntegerConverter implements Converter<Integer> {
 		}
 	}
 
+	@Override
 	public String toString(Integer value) {
 		if(value == null) {
 			return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/beans/StrokeConverter.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/beans/StrokeConverter.java
@@ -29,6 +29,7 @@ import java.text.ParseException;
  */
 public class StrokeConverter implements Converter<Stroke> {
 
+    @Override
 	public Stroke fromString(String strValue) throws ParseException {
 		if(strValue == null) {
 			return null;
@@ -40,6 +41,7 @@ public class StrokeConverter implements Converter<Stroke> {
 		}
 	}
 
+	@Override
 	public String toString(Stroke value) {
 		if(value == null) {
 			return null;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActClear.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActClear.java
@@ -34,7 +34,8 @@ class ActClear extends RichAction {
     ActClear(PnlEDTMonitor _owner) {
         owner = _owner;
     }
-    
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         owner.clearProblems();
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActTrace.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/ActTrace.java
@@ -37,7 +37,8 @@ public class ActTrace extends RichAction {
     ActTrace(PnlEDTMonitor _owner) {
         owner = _owner;
     }
-    
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         Problem[] problems = owner.getSelectedProblems();
         if(problems == null) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/MdlEDTMonitor.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/MdlEDTMonitor.java
@@ -108,10 +108,11 @@ public class MdlEDTMonitor {
             
         }
 
+        @Override
         public void problemOccured(final Problem problem) {
             // notify all listeners about the problem in the EDT
             SwingUtilities.invokeLater(new Runnable() {
-                public void run() {
+                @Override public void run() {
                     listenerSupport.getDispatcher().problemOccured(problem);
                 }
             });

--- a/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/PnlEDTMonitor.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/edt_monitor/PnlEDTMonitor.java
@@ -74,7 +74,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
         JSpinner.DefaultEditor editor = (DefaultEditor)spnDelay.getEditor();
         editor.getTextField().setFocusLostBehavior(JFormattedTextField.COMMIT_OR_REVERT);
         spnDelay.addChangeListener(new ChangeListener() {
-            public void stateChanged(ChangeEvent e) {
+            @Override public void stateChanged(ChangeEvent e) {
                 mdlMonitor.setMinimalMonitoredHangTime(((Number)spnDelay.getValue()).intValue());
             }
         });
@@ -96,9 +96,9 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
         initActions();
         
         treProblems.addMouseMotionListener(new MouseMotionListener() {
-			public void mouseDragged(MouseEvent e) {
+			@Override public void mouseDragged(MouseEvent e) {
 			}
-			public void mouseMoved(MouseEvent e) {
+			@Override public void mouseMoved(MouseEvent e) {
 		        if(getLink(e.getPoint()) != null) {
 		        	treProblems.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 				} else {
@@ -202,7 +202,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
         chbEDTViolations.setText("EDT violations");
         chbEDTViolations.setToolTipText("Monitor violations of event diapatch thread");
         chbEDTViolations.addItemListener(new java.awt.event.ItemListener() {
-            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+            @Override public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 chbEDTViolationsItemStateChanged(evt);
             }
         });
@@ -212,7 +212,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
         chbHangs.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
         chbHangs.setHorizontalTextPosition(javax.swing.SwingConstants.RIGHT);
         chbHangs.addItemListener(new java.awt.event.ItemListener() {
-            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+            @Override public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 chbHangsItemStateChanged(evt);
             }
         });
@@ -229,7 +229,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
 
         chbEDTExceptions.setText("EDT exceptions");
         chbEDTExceptions.addItemListener(new java.awt.event.ItemListener() {
-            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+            @Override public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 chbEDTExceptionsItemStateChanged(evt);
             }
         });
@@ -384,6 +384,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
 
     
     class ProblemListenerImpl implements ProblemListener {
+        @Override
         public void problemOccured(Problem problem) {
             addProblem(problem);
         }
@@ -391,6 +392,7 @@ public class PnlEDTMonitor extends javax.swing.JPanel {
     
     
     class ModelPropertyChangeListener implements PropertyChangeListener {
+        @Override
         public void propertyChange(PropertyChangeEvent evt) {
             if("monitorViolations".equals(evt.getPropertyName())) {
                 chbEDTViolations.setSelected((Boolean)evt.getNewValue());

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/FrmInterpret.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/FrmInterpret.java
@@ -65,11 +65,13 @@ public class FrmInterpret extends Frame {
 		xgraphics = xg;		
 		
 		btnRun.addActionListener(new ActionListener() {
+		    @Override
 			public void actionPerformed(ActionEvent e) {
 				callback.run();
 			}
 		});
 		btnStep.addActionListener(new ActionListener() {
+		    @Override
 			public void actionPerformed(ActionEvent e) {
 				doStep();
 			}			
@@ -78,8 +80,7 @@ public class FrmInterpret extends Frame {
 		execService = Executors.newSingleThreadExecutor();
 		
 		addWindowListener(new WindowAdapter(){
-
-
+            @Override
 			public void windowClosing(WindowEvent e) {
 				dispose();
 				execService.shutdown();
@@ -92,6 +93,7 @@ public class FrmInterpret extends Frame {
 
 	private void doStart() {
 		Runnable runnable = new Runnable() {
+		    @Override
 			public void run() {	
 				try {
 					xgraphics.interpret(drawing.getGraphics(), xgraphics.getOperationCount(), callback);
@@ -117,6 +119,7 @@ public class FrmInterpret extends Frame {
 			isRunning = true;
 			notify();
 		}
+		@Override
 		public synchronized void operationPerformed(Operation op, Graphics g) {
 			Graphics drg = drawing.getGraphics().create();
 			drg.setColor(g.getColor());

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Operation.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Operation.java
@@ -84,7 +84,8 @@ public class Operation {
 	boolean isDispose() {
 		return "dispose".equals(method.getName());
 	}
-	
+
+	@Override
 	public String toString() {
 		if(isEndOperation()) {
 			return "END.";

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Player.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/Player.java
@@ -69,7 +69,8 @@ public class Player {
 			name = nameP;
 		}
 		String name;
-		
+
+		@Override
 		public String toString() {
 			return name;
 		}
@@ -78,6 +79,7 @@ public class Player {
     /** Creates a new instance of Player */
     public Player() {
     	playTimer = new Timer(50, new ActionListener() {
+    	    @Override
 			public void actionPerformed(ActionEvent e) {
 				doStep();
 				if(getCurrentOperation().isEndOperation()) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/graphics/XGraphics.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/graphics/XGraphics.java
@@ -98,6 +98,7 @@ public class XGraphics extends Graphics2D {
 		return detachOps;
 	}
 
+	@Override
 	public void finalize() {
 		callback = null;
 		

--- a/swingexplorer-core/src/main/java/org/swingexplorer/idesupport/IDESupport.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/idesupport/IDESupport.java
@@ -121,12 +121,12 @@ public class IDESupport extends NotificationBroadcasterSupport implements IDESup
     	}
     }
     
-
+    @Override
 	public void connect() {
 		connected = true;
 	}
 
-
+    @Override
 	public void disconnect() {
 		connected = false;
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDisplayComponent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDisplayComponent.java
@@ -41,7 +41,8 @@ public class ActDisplayComponent extends RichAction {
 		model = modelP;
                 pnlComponentTree = pnlComponentTreeP;
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		Component selected = pnlComponentTree.getSelectedComponent();
         try {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDisplayParent.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDisplayParent.java
@@ -36,7 +36,8 @@ public class ActDisplayParent extends RichAction {
         application = _launcher;
         setIcon("display_parent.png");
     }
-    
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         try {
             Component comp = application.model.getDisplayedComponent();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDisplayTopContainer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDisplayTopContainer.java
@@ -36,7 +36,8 @@ public class ActDisplayTopContainer extends RichAction {
         application = _launcher;
         setIcon("display_top.png");
     }
-    
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         try {
             Component comp = application.model.getDisplayedComponent();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDumpAdditionTrace.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActDumpAdditionTrace.java
@@ -41,7 +41,8 @@ public class ActDumpAdditionTrace extends RichAction {
         pnlComponentTree = _pnlComponentTree;
         mdlSwingExplorer = _mdlSwingExplorer;
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		if(!Agent.isInstrumented()) {
 			PnlNoAgentModeMessage.openDialog(pnlComponentTree);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActHelp.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActHelp.java
@@ -34,6 +34,7 @@ public class ActHelp extends RichAction {
 		setTooltip("User documentation");
 	}
 
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		if(!SysUtils.openBrowser("http://www.swingexplorer.com/?page=documentation")) {
 			JOptionPane.showMessageDialog(null, "Can not open browser!", "Error", JOptionPane.ERROR_MESSAGE);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActHelpAbout.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActHelpAbout.java
@@ -37,6 +37,7 @@ public class ActHelpAbout extends RichAction {
 		owner = ownerP;
 	}
 
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		PnlAbout.openModal(owner);
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActKeyOnDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActKeyOnDisplay.java
@@ -35,16 +35,19 @@ public class ActKeyOnDisplay implements KeyListener {
 		display = displayP;
 		model = modelP;
 	}
-	
+
+	@Override
 	public void keyPressed(KeyEvent e) {
 		if(e.getKeyCode() == KeyEvent.VK_ESCAPE) {
 			model.setMeasurePoint1(null);
 		}
 	}
 
+	@Override
 	public void keyReleased(KeyEvent e) {
 	}
 
+	@Override
 	public void keyTyped(KeyEvent e) {
 	}
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActMoveOverDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActMoveOverDisplay.java
@@ -38,6 +38,7 @@ public class ActMoveOverDisplay extends MouseAdapter implements MouseMotionListe
 		model = modelP;
 	}
 
+	@Override
 	public void mouseMoved(MouseEvent e) {
 		Component over = display.getDisplayedComponentAt(e.getPoint());
 		model.setCurrentComponent(over);
@@ -46,12 +47,14 @@ public class ActMoveOverDisplay extends MouseAdapter implements MouseMotionListe
             model.setMouseLocation(e.getPoint());
 		}
 	}
-	
+
+	@Override
 	public void mouseExited(MouseEvent e) {
 		model.setCurrentComponent(null);
 		model.setMouseLocation(null);
 	}
 
+	@Override
 	public void mouseDragged(MouseEvent e) {
 	}
 }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActOpenPlayer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActOpenPlayer.java
@@ -40,7 +40,8 @@ public class ActOpenPlayer extends RichToggleAction {
 		setIcon(DefaultIcon.INSTANCE);
 		model = modelP;
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		setSelected(!isSelected());
 		

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActOpenSourceCode.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActOpenSourceCode.java
@@ -41,7 +41,8 @@ public class ActOpenSourceCode extends RichAction {
         setTooltip("Open sourcecode in IDE");
         owner = _owner;
     }
-    
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         
         Operation op = owner.player.getCurrentOperation();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActRefresh.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActRefresh.java
@@ -99,7 +99,8 @@ public class ActRefresh extends RichAction {
 //            }
 //        }, 0xFFFFFFFFFFFFFFFL);
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		
 		Log.general.debug("Refresh component tree");

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActShowEventSource.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActShowEventSource.java
@@ -45,6 +45,7 @@ public class ActShowEventSource extends RichAction {
 		setTooltip("Select component the event comes from");
 	}
 
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		AWTEvent evt = pnlAwtEvents.getSelectedEvent();
 		if(evt == null) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActTreeSelectionChanged.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActTreeSelectionChanged.java
@@ -40,6 +40,7 @@ public class ActTreeSelectionChanged implements TreeSelectionListener {
         pnlComponentTree = pnlComponentTreeP;
     }
 
+    @Override
     public void valueChanged(TreeSelectionEvent e) {
 	    TreePath[] paths = e.getPaths();
 		for (TreePath curPath : paths) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActZoomIn.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActZoomIn.java
@@ -36,6 +36,7 @@ public class ActZoomIn extends RichAction {
         model = modelP;
 	}
 
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		// 
 		double curScale = model.getDisplayScale();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActZoomOut.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ActZoomOut.java
@@ -35,7 +35,8 @@ public class ActZoomOut extends RichAction {
         setIcon("zoom_out.png");
 		this.model = model;
 	}
-	
+
+	@Override
 	public void actionPerformed(ActionEvent e) {
 		double curScale = model.getDisplayScale();
 		

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/AnimatedIcon.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/AnimatedIcon.java
@@ -46,15 +46,18 @@ public class AnimatedIcon implements Icon {
     private Timer timer;
     private int iconNumber = 0;
     private boolean inProgress = false;
-    
+
+    @Override
     public int getIconHeight() {
         return currentIcon.getIconHeight();
     }
 
+    @Override
     public int getIconWidth() {
         return currentIcon.getIconWidth();
     }
 
+    @Override
     public void paintIcon(Component c, Graphics g, int x, int y) {
         currentIcon.paintIcon(c, g, x, y);
     }
@@ -95,11 +98,13 @@ public class AnimatedIcon implements Icon {
             // this is necessary to switch off timer when
             // progress indicator becomes invisible
             ownerComponent.addComponentListener(new ComponentAdapter() {
+                @Override
                 public void componentHidden(ComponentEvent e) {
                     if(inProgress) {
                         timer.stop();
                     }
                 }
+                @Override
                 public void componentShown(ComponentEvent e) {
                     if(inProgress) {
                         timer.start();
@@ -113,6 +118,7 @@ public class AnimatedIcon implements Icon {
     
     private void initActions(){
         timer = new Timer(100, new ActionListener(){
+            @Override
             public void actionPerformed(ActionEvent e) {
                 if(icons.size() > 0) {
                     iconNumber = (iconNumber + 1) % icons.size();
@@ -179,13 +185,16 @@ public class AnimatedIcon implements Icon {
             }
             icon = _icon;
         }
-        
+
+        @Override
         public int getIconHeight() {
             return maxIconSize.height;
         }
+        @Override
         public int getIconWidth() {
             return maxIconSize.width;
         }
+        @Override
         public void paintIcon(Component c, Graphics g, int x, int y) {
 
             // calculate shift of icon
@@ -208,12 +217,15 @@ public class AnimatedIcon implements Icon {
     
     // icon for inactive state
     class EmptyIcon implements Icon {
+        @Override
         public int getIconHeight() {
             return maxIconSize.height;
         }
+        @Override
         public int getIconWidth() {
             return maxIconSize.width;
         }
+        @Override
         public void paintIcon(Component c, Graphics g, int x, int y) {
         }
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/AnimatedLabel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/AnimatedLabel.java
@@ -87,11 +87,13 @@ public class AnimatedLabel extends JLabel {
             // this is necessary to switch off timer when
             // progress indicator becomes invisible
             addComponentListener(new ComponentAdapter() {
+                @Override
                 public void componentHidden(ComponentEvent e) {
                     if(inProgress) {
                         timer.stop();
                     }
                 }
+                @Override
                 public void componentShown(ComponentEvent e) {
                     if(inProgress) {
                         timer.start();
@@ -105,6 +107,7 @@ public class AnimatedLabel extends JLabel {
     
     private void initActions(){
         timer = new Timer(100, new ActionListener(){
+            @Override
             public void actionPerformed(ActionEvent e) {
                 if(icons.size() > 0) {
                     iconNumber = (iconNumber + 1) % icons.size();
@@ -171,13 +174,16 @@ public class AnimatedLabel extends JLabel {
             }
             icon = _icon;
         }
-        
+
+        @Override
         public int getIconHeight() {
             return maxIconSize.height;
         }
+        @Override
         public int getIconWidth() {
             return maxIconSize.width;
         }
+        @Override
         public void paintIcon(Component c, Graphics g, int x, int y) {
 
             // calculate shift of icon
@@ -200,12 +206,15 @@ public class AnimatedLabel extends JLabel {
     
     // icon for inactive state
     class EmptyIcon implements Icon {
+        @Override
         public int getIconHeight() {
             return maxIconSize.height;
         }
+        @Override
         public int getIconWidth() {
             return maxIconSize.width;
         }
+        @Override
         public void paintIcon(Component c, Graphics g, int x, int y) {
         }
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/Application.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/Application.java
@@ -27,7 +27,7 @@ public class Application implements Runnable {
 
     private PersonalizerRegistry personalizerRegistry;
 
-
+    @Override
     public void run() {
         // register JMX bean for IDE support
         ideSupport = IDESupport.registerMBean();
@@ -37,7 +37,7 @@ public class Application implements Runnable {
         frmMain = new FrmSwingExplorer();
         frmMain.setName("frmMain");
         frmMain.addWindowListener(new WindowAdapter() {
-            public void windowClosing(WindowEvent evt) {
+            @Override public void windowClosing(WindowEvent evt) {
                 exitApplication();
             }
         });

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/ColorComboBox.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/ColorComboBox.java
@@ -65,6 +65,7 @@ public class ColorComboBox extends JComboBox<Color> {
 	}
 
 	@SuppressWarnings("unchecked")
+    @Override
 	public void setRenderer(ListCellRenderer aRenderer) {
         super.setRenderer(aRenderer);
     }
@@ -79,7 +80,8 @@ public class ColorComboBox extends JComboBox<Color> {
 		ColorCellRenderer() {
 			setPreferredSize(new Dimension(50, 20));
 		}
-		
+
+		@Override
 		public Component getListCellRendererComponent(JList _list, Object _value,
 				int _index, boolean _isSelected, boolean _cellHasFocus) {
 			super.getListCellRendererComponent(_list, _value, _index, _isSelected, _cellHasFocus);
@@ -112,6 +114,7 @@ public class ColorComboBox extends JComboBox<Color> {
 		frm.setBounds(new java.awt.Rectangle(100, 100, 200, 200));
 		ColorComboBox cmb = new ColorComboBox();
 		cmb.addItemListener(new java.awt.event.ItemListener(){
+		    @Override
 			public void itemStateChanged(java.awt.event.ItemEvent e) {
 				System.out.println(" Changed " + e);
 			}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/DefaultIcon.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/DefaultIcon.java
@@ -37,15 +37,18 @@ public class DefaultIcon implements Icon {
     private DefaultIcon() {
     }
 
+    @Override
     public void paintIcon(Component c, Graphics g, int x, int y) {
         g.setColor(Color.BLUE);
         g.fillRect(x, y, getIconWidth(),getIconHeight());
     }
 
+    @Override
     public int getIconWidth() {
         return 16;
     }
 
+    @Override
     public int getIconHeight() {
         return 16;
     }    

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/DlgLicense.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/DlgLicense.java
@@ -67,6 +67,7 @@ public class DlgLicense extends JDialog {
 		this.setTitle("License");
 		
 		btnClose.addActionListener(new ActionListener() {
+		    @Override
 			public void actionPerformed(ActionEvent arg0) {
 				DlgLicense.this.dispose();
 			}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/FrmSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/FrmSwingExplorer.java
@@ -95,7 +95,7 @@ public class FrmSwingExplorer extends JFrame {
 			public void componentShown(ComponentEvent e) {
  			    // invoke refresh
 		        SwingUtilities.invokeLater(new Runnable() {
-		        	public void run() {  
+		        	@Override public void run() {
 		        		pnlSwingExplorer.actRefresh.actionPerformed(null);
 		        	}
 		        });

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/GuiUtils.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/GuiUtils.java
@@ -356,6 +356,7 @@ final public class GuiUtils {
             if (action != null) {
 
                 JMenuItem item = new JMenuItem(action) {
+                    @Override
                     public void setText(String text) {
                         super.setText(GuiUtils.getTextWithoutMnemonic(text));
                     }
@@ -405,6 +406,7 @@ final public class GuiUtils {
         // Adding listener. If added after size settings - will not be added if
         // one of arguments is NULL.
         component.addComponentListener(new java.awt.event.ComponentAdapter() {
+            @Override
             public void componentResized(ComponentEvent e) {
                 Dimension curSize = component.getSize();
                 if (curSize.width < minSize.width || curSize.height < minSize.height) {
@@ -481,6 +483,7 @@ final public class GuiUtils {
 
         // Adding exit listener
         frame.addWindowListener(new WindowAdapter() {
+            @Override
             public void windowClosing(WindowEvent e) {
                 System.exit(0);
             }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/IconPanel.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/IconPanel.java
@@ -74,7 +74,8 @@ public class IconPanel extends JComponent {
 	public double getScale() {
 		return scale;
 	}
-	
+
+	@Override
 	public void paint(Graphics g) {
 		Graphics2D g2d = (Graphics2D)g;
 		if(icon != null) {
@@ -91,6 +92,7 @@ public class IconPanel extends JComponent {
 		}
 	}
 
+	@Override
 	public Dimension getPreferredSize() {
 		if(icon == null) {
 			return new Dimension(0, 0);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlAbout.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlAbout.java
@@ -158,7 +158,8 @@ public class PnlAbout extends javax.swing.JPanel {
 
 			}
 		}
-		
+
+		@Override
 		public Dimension getPreferredSize() {
 			return new Dimension(13, 13);
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlComponentDetails.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlComponentDetails.java
@@ -183,6 +183,7 @@ public class PnlComponentDetails extends javax.swing.JPanel {
     
     class ModelListener implements PropertyChangeListener {
 
+        @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String propName = evt.getPropertyName();
 			if (!"selectedComponents".equals(propName)) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlComponentTree.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlComponentTree.java
@@ -315,6 +315,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
 			this.act = act;
 		}
 
+		@Override
 		public void mouseClicked(MouseEvent e) {
 			if (e.getClickCount() > 1) {
 		        // fire aciton on double click:
@@ -376,11 +377,13 @@ public class PnlComponentTree extends javax.swing.JPanel {
 		public Component getComponent() {
 			return (Component) objRef.get();
 		}
-		
+
+		@Override
 		public String toString() {
 			return name;
 		}
-		
+
+		@Override
 		public boolean equals(Object o) {
 			if(!(o instanceof TreeNodeObject)) {
 				return false;
@@ -393,6 +396,7 @@ public class PnlComponentTree extends javax.swing.JPanel {
 	
 	class ModelListener implements PropertyChangeListener {
 
+        @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String propName = evt.getPropertyName();
 			if ("selectedComponents".equals(propName)) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlGuiDisplay.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlGuiDisplay.java
@@ -331,6 +331,7 @@ public class PnlGuiDisplay extends JComponent {
 
 	class ModelListener implements PropertyChangeListener {
 
+	    @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String propName = evt.getPropertyName();
 			if ("displayedComponentImage".equals(propName)) {
@@ -369,7 +370,7 @@ public class PnlGuiDisplay extends JComponent {
 		repaint();
 	}
 
-
+	@Override
 	public Dimension getPreferredSize() {
 
 		if(model == null) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlNoAgentModeMessage.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlNoAgentModeMessage.java
@@ -53,6 +53,7 @@ public class PnlNoAgentModeMessage extends javax.swing.JPanel {
 
         btnCopy.setText("Copy to clipboard");
         btnCopy.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnCopyActionPerformed(evt);
             }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlOptions.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlOptions.java
@@ -62,6 +62,7 @@ public class PnlOptions extends javax.swing.JPanel {
         btnReset.setText("Reset");
         btnReset.setToolTipText("Reset options to defaults");
         btnReset.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnResetActionPerformed(evt);
             }
@@ -193,7 +194,8 @@ public class PnlOptions extends javax.swing.JPanel {
     	void enable() {
     		disabled = false;
     	}
-    	
+
+    	@Override
 		public void itemStateChanged(ItemEvent evt) {
 			if(disabled) {
 				return;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlPlayerControls.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlPlayerControls.java
@@ -72,7 +72,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
         lstOperations.setModel(new OperationListModel());
         lstOperations.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
         lstOperations.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
+            @Override public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
                 lstOperationsValueChanged(evt);
             }
         });
@@ -80,18 +80,18 @@ public class PnlPlayerControls extends javax.swing.JPanel {
 
         slider.setValueIsAdjusting(true);
         slider.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+            @Override public void stateChanged(javax.swing.event.ChangeEvent evt) {
                 sliderStateChanged(evt);
             }
         });
         slider.addMouseListener(new java.awt.event.MouseAdapter() {
-            public void mouseReleased(java.awt.event.MouseEvent evt) {
+            @Override public void mouseReleased(java.awt.event.MouseEvent evt) {
                 sliderMouseReleased(evt);
             }
         });
 
         spinner.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+            @Override public void stateChanged(javax.swing.event.ChangeEvent evt) {
                 spinnerStateChanged(evt);
             }
         });
@@ -327,17 +327,21 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     }
     
     class PlayerListenerImpl implements PlayerListener {
+        @Override
         public void imageRendered(ImageEvent evt) {
         }
 
+        @Override
 		public void operationsReset(OperationResetEvent evt) {
 			updateOperationList();
 		}
 
+		@Override
 		public void stateChanged(StateEvent evt) {
 			updateActionAvailabilityFromState(evt.getNewState());
 		}
 
+		@Override
 		public void currentOperationChanged(CurrentOperationChangeEvent evt) {
 			blockEventsFromControls = true;
         	Operation op = evt.getCurrentOperation();
@@ -366,11 +370,13 @@ public class PnlPlayerControls extends javax.swing.JPanel {
     		 super.fireIntervalAdded(this, 0, operations.length - 1);
     		}
     	}
-    	
+
+    	@Override
 		public int getSize() {
 			return operations.length;
 		}
 
+		@Override
 		public Operation getElementAt(int index) {
 			return operations[index];
 		}    	
@@ -382,6 +388,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Play");
             setIcon("play.png");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             player.play();
@@ -392,6 +399,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Play Step");
             setIcon("play_step.png");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             player.playStep();
@@ -402,6 +410,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Pause");
             setIcon("pause.png");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             player.pause();
@@ -413,6 +422,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Go to start");
             setIcon("to_start.png");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             player.seek(0);
@@ -424,6 +434,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Go to end");
             setIcon("to_end.png");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             player.seek(player.getOperationCount() - 1);
@@ -435,6 +446,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Play step back");
             setIcon("play_step_back.png");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             player.playStepBack();
@@ -446,6 +458,7 @@ public class PnlPlayerControls extends javax.swing.JPanel {
             setTooltip("Dump current operation's stack trace");
             setName("Trace");
         }
+        @Override
         public void actionPerformed(ActionEvent e) {
             Player player = getPlayer();
             Operation op = player.getCurrentOperation();

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlSelectionProperties.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlSelectionProperties.java
@@ -34,6 +34,7 @@ public class PnlSelectionProperties extends javax.swing.JPanel {
     }
     
     class ModelListener implements PropertyChangeListener {
+        @Override
         public void propertyChange(PropertyChangeEvent evt) {
             String propName = evt.getPropertyName();
             if (!"selectedComponents".equals(propName)) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlStatusBar.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlStatusBar.java
@@ -105,6 +105,7 @@ public class PnlStatusBar extends javax.swing.JPanel {
     
     class ModelListener implements PropertyChangeListener {
 
+        @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String propName = evt.getPropertyName();
 			if ("mouseLocation".equals(propName)) {

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlSwingExplorer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/PnlSwingExplorer.java
@@ -62,6 +62,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
         icoEventMonitoring.setIcons(Icons.monitor());
         AWTEventModel awtEventModel = pnlAWTEvents.getEventModel();
         awtEventModel.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 if("monitoring".equals(evt.getPropertyName())) {
                     Boolean value = (Boolean)evt.getNewValue();
@@ -84,6 +85,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
         icoEDTMonitoring.setIcons(Icons.monitor());
         final MdlEDTMonitor mdlEDTMonitor = pnlEDTMonitor.getModel();
         mdlEDTMonitor.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 if("monitorViolations".equals(evt.getPropertyName()) ||  
                     "monitorHangs".equals(evt.getPropertyName()) ||
@@ -378,6 +380,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
     		}
     		application.model.setDisplayScale(Double.parseDouble(item.toString())/100);	
     	}
+    	@Override
 		public void itemStateChanged(ItemEvent e) {
 			if(ItemEvent.SELECTED == e.getStateChange()) {
 				if(!cmbScale.isPopupVisible()) {
@@ -385,11 +388,14 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
 				}
 			}			
 		}
+		@Override
 		public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
 			changeScale();		
 		}
+		@Override
 		public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
 		}
+		@Override
 		public void popupMenuCanceled(PopupMenuEvent e) {
 		}
     }
@@ -401,7 +407,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
 
     
     class ModelListener implements PropertyChangeListener {
-
+        @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String propName = evt.getPropertyName();
 			if ("displayedComponent".equals(propName)) {
@@ -416,7 +422,7 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
 	}
     
     class PlayerListenerImpl implements PlayerListener {
-    	
+    	@Override
 		public void imageRendered(ImageEvent evt) {
             // listener should be removed and restored after
             // setDisplayedComponentImage to avoid redundant reaction on
@@ -430,12 +436,15 @@ public class PnlSwingExplorer extends javax.swing.JPanel {
             application.model.addPropertyChangeListener(listener);
 		}
 
+		@Override
 		public void stateChanged(StateEvent evt) {
 		}
 
+		@Override
 		public void operationsReset(OperationResetEvent operations) {
 		}
 
+		@Override
 		public void currentOperationChanged(CurrentOperationChangeEvent evt) {
 			
 		}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/RichToggleButton.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/RichToggleButton.java
@@ -70,7 +70,7 @@ public class RichToggleButton extends JToggleButton {
 	}
 	
 	class SelectionStateListener implements PropertyChangeListener {
-
+        @Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			if(evt.getPropertyName().equals("selected")) {
 				setSelected((Boolean)evt.getNewValue());

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/RichToolbar.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/RichToolbar.java
@@ -50,6 +50,7 @@ public class RichToolbar extends JToolBar {
 			b.setText("");
 		} else {
 			b = new JButton(text, icon) {
+			    @Override
 				protected PropertyChangeListener createActionPropertyChangeListener(
 						Action a) {
 					PropertyChangeListener pcl = createActionChangeListener(this);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/internal/RulerBorder.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/internal/RulerBorder.java
@@ -35,15 +35,17 @@ public class RulerBorder implements Border{
 	
 	MdlSwingExplorer model;
 	
-	
+	@Override
 	public Insets getBorderInsets(Component c) {
 		return new Insets(20, 20, 0, 0);
 	}
 
+	@Override
 	public boolean isBorderOpaque() {
 		return true;
 	}
 
+	@Override
 	public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
 		g.setColor(c.getBackground());
 		g.fillRect(0, 0, 20, 20);

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/AbstractOnResizePersonalizer.java
@@ -37,6 +37,7 @@ public abstract class AbstractOnResizePersonalizer<T extends Component> implemen
 	protected T component;
 
 	@SuppressWarnings("unchecked")
+    @Override
 	public void install(Options _options, Component _component) {
 		component = (T)_component;
 		options = _options;
@@ -45,7 +46,7 @@ public abstract class AbstractOnResizePersonalizer<T extends Component> implemen
 	
 	class ResizeListener extends ComponentAdapter{
     	int count = 0;
-    	public void componentResized(ComponentEvent e) {
+    	@Override public void componentResized(ComponentEvent e) {
     		applyState();
     		component.removeComponentListener(this);
 		}
@@ -60,6 +61,7 @@ public abstract class AbstractOnResizePersonalizer<T extends Component> implemen
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public abstract void saveState();
 }
 

--- a/swingexplorer-core/src/main/java/org/swingexplorer/personal/FramePersonalizer.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/personal/FramePersonalizer.java
@@ -33,13 +33,15 @@ public class FramePersonalizer implements Personalizer {
 	
 	private Options options;
 	private JFrame frame;
-	
+
+	@Override
 	public void install(Options _options, Component _component) {
 		options = _options;
 		frame = (JFrame)_component;
 		frame.setBounds(_options.getWindowX(), _options.getWindowY(), _options.getWindowWidth(), _options.getWindowHeight());
 	}
 
+	@Override
 	public void saveState() {
 		options.setWindowX(frame.getX());
 		options.setWindowY(frame.getY());

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomComboBoxUI.java
@@ -46,7 +46,8 @@ public class CustomComboBoxUI extends MetalComboBoxUI {
         comboBox.setFont(PlafUtils.CUSTOM_FONT);
         
     }
-    
+
+    @Override
     public void paint( Graphics g, JComponent c ) {
         hasFocus = comboBox.hasFocus();
         if ( !comboBox.isEditable() ) {
@@ -63,6 +64,7 @@ public class CustomComboBoxUI extends MetalComboBoxUI {
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public void paintCurrentValue(Graphics g,Rectangle bounds,boolean hasFocus) {
         ListCellRenderer renderer = comboBox.getRenderer();
         Component c;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomSplitPaneDivider.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomSplitPaneDivider.java
@@ -36,7 +36,8 @@ public class CustomSplitPaneDivider extends BasicSplitPaneDivider {
 	CustomSplitPaneDivider(BasicSplitPaneUI ui) {
 		super(ui);		
 	}
-	
+
+	@Override
 	public void setDividerSize(int newSize) {
         dividerSize = newSize;
     }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomSplitPaneUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomSplitPaneUI.java
@@ -34,6 +34,7 @@ public class CustomSplitPaneUI extends BasicSplitPaneUI {
 	    	return new CustomSplitPaneUI();
 	    }
 
+	    @Override
 	    protected void installDefaults() {
 	    	super.installDefaults();
 	    	getDivider().setDividerSize(3);
@@ -43,6 +44,7 @@ public class CustomSplitPaneUI extends BasicSplitPaneUI {
 	    /**
 	      * Creates the default divider.
 	      */
+	    @Override
 	    public BasicSplitPaneDivider createDefaultDivider() {
 	    	return new CustomSplitPaneDivider(this);
 	    }

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTabbedPaneUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTabbedPaneUI.java
@@ -44,6 +44,7 @@ public class CustomTabbedPaneUI extends MetalTabbedPaneUI {
 			int selectedIndex, int x, int y, int w, int h) {
 	}
 
+	@Override
 	protected void paintContentBorder(Graphics g, int tabPlacement,
 			int selectedIndex) {
 		int width = tabPane.getWidth();
@@ -76,6 +77,7 @@ public class CustomTabbedPaneUI extends MetalTabbedPaneUI {
 		paintContentBorderTopEdge(g, tabPlacement, selectedIndex, x, y, w, h);
 	}
 
+	@Override
 	protected void paintTabBackground(Graphics g, int tabPlacement,
 			int tabIndex, int x, int y, int w, int h, boolean isSelected) {
 		int slantWidth = h / 2;

--- a/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTableHeaderUI.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/plaf/CustomTableHeaderUI.java
@@ -58,6 +58,7 @@ public class CustomTableHeaderUI extends BasicTableHeaderUI {
             
         }
 
+        @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                 boolean isSelected, boolean hasFocus, int row, int column) {
             

--- a/swingexplorer-core/src/main/java/org/swingexplorer/properties/MdlProperties.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/properties/MdlProperties.java
@@ -197,6 +197,7 @@ public class MdlProperties extends AbstractTableModel {
 			}
             
             Arrays.sort(properties, new Comparator<String[]>() {
+                @Override
                 public int compare(String[] o1, String[] o2) {
                     String key1 = o1[0];
                     String key2 = o2[0];
@@ -227,15 +228,18 @@ public class MdlProperties extends AbstractTableModel {
 	public Object getBean() {
 		return bean;
 	}
-	
+
+	@Override
 	public int getColumnCount() {
 		return 2;
 	}
 
+	@Override
 	public int getRowCount() {
 		return properties.length;
 	}
 
+	@Override
 	public Object getValueAt(int rowIndex, int columnIndex) {
 		return properties[rowIndex][columnIndex];
 	}

--- a/swingexplorer-core/src/main/java/org/swingexplorer/util/ListenerSupport.java
+++ b/swingexplorer-core/src/main/java/org/swingexplorer/util/ListenerSupport.java
@@ -67,6 +67,7 @@ public class ListenerSupport<L> {
     }
     
     class InvocationHandlerImpl implements InvocationHandler {
+        @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             
             Object[] arrListeners;


### PR DESCRIPTION
What do you think about using `@Override` annotations? It's considered good practice these days, and it would make the Swing Explorer code base play nicer with static analysis tools, which may help us catch other code issues.

This PR adds `@Override` annotations to all the overriding methods that don't already have the annotation.

(This is low-hanging fruit for static analyzers. Once this is cleared out of the way, we can use Error Prone etc. to pick out more interesting potential code issues.)